### PR TITLE
Disable service worker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,5 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
-registerServiceWorker();


### PR DESCRIPTION
This has caching behavior that leads to users not getting the latest code immediately on deploy.  We could look at adding this in later but don't want this kind of cache behavior right now.