### PR TITLE
Add spring up for Swipeable

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react-scripts": "1.0.13"
   },
   "dependencies": {
+    "animated": "^0.2.0",
     "prop-types": "^15.6.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,8 @@
 .App {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .App-logo {

--- a/src/App.js
+++ b/src/App.js
@@ -54,6 +54,7 @@ class App extends Component {
           <h2>cheesy first change</h2>
         </div>
         <Swipeable
+          height={200}
           onSwipeLeft={this.onSwipeLeft.bind(this, question, argument)}
           onSwipeRight={this.onSwipeRight.bind(this, question, argument)}>
           hello!

--- a/src/Swipeable.css
+++ b/src/Swipeable.css
@@ -1,4 +1,6 @@
-.Swipeable {
+.Swipeable-items {
   display: flex;
   justify-content: space-between;
+  border: 1px solid black;
+  height: 100%;
 }

--- a/src/Swipeable.js
+++ b/src/Swipeable.js
@@ -1,18 +1,46 @@
 import React, { Component } from 'react';
 import './Swipeable.css';
 import PropTypes from 'prop-types';
+import Animated from 'animated/lib/targets/react-dom';
 
-// A card that can be swiped left or right, handling those animations and interactions
-// and calling back to the props when either occurs.
-// TODO: update with react-swipeable-views
+// A card that springs up and then can be swiped left or right,
+// handling those animations and interactions and calling back to
+// the props when either occurs.
 class Swipeable extends Component {
-  render() {
-    const {children, onSwipeLeft, onSwipeRight} = this.props;
+  constructor(props) {
+    super(props);
+    this.state = {
+      animTop: new Animated.Value(props.height),
+    };
+  }
 
+  componentDidMount() {
+    const {animTop} = this.state;
+    Animated.spring(animTop, { toValue: 0.0 }).start();
+  }
+
+  render() {
+    const {height} = this.props;
+    const {animTop} = this.state;
+
+    // Spring up
     return (
-      <div className="Swipeable">
+      <div className="Swipeable" style={{height: height}}>
+        <Animated.div
+          style={{position: 'relative', top: animTop}}>
+          {this.renderSwipeable()}
+        </Animated.div>
+      </div>
+    );
+  }
+
+  // TODO: update with react-swipeable-views
+  renderSwipeable() {
+    const {children, onSwipeLeft, onSwipeRight} = this.props;
+    return (
+      <div className="Swipeable-items">
         <div onClick={onSwipeLeft}>left</div>
-        <div>{children}</div>
+        {children}
         <div onClick={onSwipeRight}>right</div>
       </div>
     );
@@ -21,6 +49,7 @@ class Swipeable extends Component {
 
 Swipeable.propTypes = {
   children: PropTypes.node.isRequired,
+  height: PropTypes.number.isRequired,
   onSwipeLeft: PropTypes.func.isRequired,
   onSwipeRight: PropTypes.func.isRequired
 };

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,7 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
+
+html, body, #root {
+  height: 100%;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,6 +87,13 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+animated@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/animated/-/animated-0.2.0.tgz#1a0e96f097b3fbc5b64d7eddc723bcc0a6f97633"
+  dependencies:
+    invariant "^2.2.0"
+    normalize-css-color "^1.0.1"
+
 anser@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.1.tgz#c3641863a962cebef941ea2c8706f2cb4f0716bd"
@@ -3166,7 +3173,7 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -4262,6 +4269,10 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+normalize-css-color@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"


### PR DESCRIPTION
Looks like:
![six](https://user-images.githubusercontent.com/1056957/30972102-a6843648-a437-11e7-82da-e1184c3cb661.gif)

This uses `animated` for animations (with the intent of merging towards the React Native line of work @keving17 has started, rather than continuing to use `VelocityReact` as in https://github.com/mit-teaching-systems-lab/threeflows).