### PR TITLE
Make CSS take up full height

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,9 +1,4 @@
-p {
-  font-size: 100%;
-}
-
-button{
-  align-self: center;
-  margin-bottom:40px;
+.App {
+  height: 100%;
   background-color: #00ffff;
 }

--- a/client/src/IntroductionPhase.css
+++ b/client/src/IntroductionPhase.css
@@ -9,7 +9,7 @@
   padding: 20px;
 }
 
-.IntroductionPhase-header{
+.IntroductionPhase-header {
   margin-top:0;
   margin-bottom:0;
   text-align: center;
@@ -19,10 +19,10 @@
   font-size: 25px;
 }
 
-.IntroductionPhase-body{
+.IntroductionPhase-body {
   background-color: #00ffff;
-  flex-direction:column;
-  align-items:center;
+  flex-direction: column;
+  align-items: center;
   padding: 20px;
   height: 200px;
   font-size: 100%;

--- a/client/src/IntroductionPhase.js
+++ b/client/src/IntroductionPhase.js
@@ -26,7 +26,9 @@ class IntroductionPhase extends Component {
         </p>
         <p className="IntroductionPhase-body"> For each student, read their profile and take on their perspective. Once you‘ve read some reasons teachers might use to convince them to take a computer science course. 
         </p>
-        <button onClick={this.props.onDone}>READY?</button>
+        <button
+          className="button"
+          onClick={this.props.onDone}>READY?</button>
       </div>
     );
   }

--- a/client/src/Student.css
+++ b/client/src/Student.css
@@ -1,0 +1,3 @@
+.Student { 
+  height: 100%
+}

--- a/client/src/Student.js
+++ b/client/src/Student.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Turn from './Turn.js';
-
+import './Student.css';
 
 
 

--- a/client/src/StudentsPhase.css
+++ b/client/src/StudentsPhase.css
@@ -1,0 +1,3 @@
+.StudentsPhase {
+  height: 100%;
+}

--- a/client/src/StudentsPhase.js
+++ b/client/src/StudentsPhase.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Student from './Student.js';
+import './StudentsPhase.css';
 
 
 // Show the phase where we're going through students.

--- a/client/src/Title.css
+++ b/client/src/Title.css
@@ -1,4 +1,5 @@
 .Title {
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -13,7 +14,6 @@
   text-align: center;
   display: flex;
   flex-direction: column;
-  height: 100%;
   margin-top: 0;
   background-color: #00ffff;
   color: #662e9e;

--- a/client/src/Title.js
+++ b/client/src/Title.js
@@ -10,7 +10,9 @@ class Title extends Component {
         <p className="Title-intro">
           Swipe Right for CS!    
         </p>
-        <button onClick={this.props.onDone}>CLICK ME TO PLAY</button>
+        <button
+          className="button"
+          onClick={this.props.onDone}>CLICK ME TO PLAY</button>
       </div>
     );
   }

--- a/client/src/Turn.css
+++ b/client/src/Turn.css
@@ -1,5 +1,7 @@
 .Turn {
-  background-color: #00ffff;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .Turn-student {
@@ -7,11 +9,11 @@
   flex-direction: column;
   align-items: center;
   justify-content: stretch;
+  flex: 1;
 }
 
 .Turn-profile {
   text-align:center;
   margin-right:10px;
   margin-left:10px;
-  background-color: #00ffff;
 }

--- a/client/src/Turn.js
+++ b/client/src/Turn.js
@@ -47,7 +47,7 @@ class Turn extends Component {
         </div>
         <Swipeable
           key={argumentText}
-          height={200}
+          height={150}
           onSwipeLeft={this.onSwipeLeft}
           onSwipeRight={this.onSwipeRight}>
           <div>{argumentText}</div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,44 +8,7 @@ html, body, #root {
   height: 100%;
 }
 
-#root.fake-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.fake {
-  position: relative;
-  width: 320px;
-  height: 568px !important;
-  background: #111;
-  box-shadow: 0px 0px 0px 2px #aaa;
-  z-index: 1000;
-  padding: 90px 30px;
-  border-radius: 55px;
-}
-
-.fake:before {
-  content: '';
-  width: 60px;
-  height: 10px;
-  border-radius: 10px;
-  position: absolute;
-  left: 50%;
-  margin-left: -30px;
-  background: #333;
-  top: 40px;
-}
-
-.fake:after {
-  content: '';
-  position: absolute;
-  width: 60px;
-  height: 60px;
-  left: 50%;
-  margin-left: -30px;
-  bottom: 15px;
-  border-radius: 100%;
-  box-sizing: border-box;
-  border: 5px solid #333;
+button.button {
+  align-self: center;
+  background-color: #00ffff;
 }


### PR DESCRIPTION
This adds some CSS to make each screen take up the full height, and enables removing some padding.  It also removes some CSS from `index.css` that I mistakenly added in, and adds `.button` classes for the `<button>` elements in the title and intro.

Before, changing exact pixel height doesn't fill up whole screen (extra white at the bottom):
![screen shot 2017-10-05 at 12 09 31 pm](https://user-images.githubusercontent.com/1056957/31237869-1d436d24-a9c6-11e7-8fed-8fec091b7d5f.png)


After, it takes full height:
![screen shot 2017-10-05 at 12 08 54 pm](https://user-images.githubusercontent.com/1056957/31237873-1fffcf58-a9c6-11e7-9173-e5cc8890fc2e.png)
