### PR TITLE
Improve background for MobileSimulator

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,4 +1,3 @@
 .App {
   height: 100%;
-  background-color: #00ffff;
 }

--- a/client/src/IntroductionPhase.css
+++ b/client/src/IntroductionPhase.css
@@ -1,12 +1,10 @@
 .IntroductionPhase {
+  height: 100%;
   display:flex;
   flex-direction: column;
   align-items: stretch;
   justify-content: center;
   background-color: #00ffff;
-  height:550px;
-  padding-bottom:20px;
-  padding: 20px;
 }
 
 .IntroductionPhase-header {
@@ -24,7 +22,6 @@
   flex-direction: column;
   align-items: center;
   padding: 20px;
-  height: 200px;
   font-size: 100%;
   color: #662e9e;
 }

--- a/client/src/MobileSimulator.css
+++ b/client/src/MobileSimulator.css
@@ -7,6 +7,10 @@
   user-select: none;
 }
 
+.MobileSimulator-not-wide {
+  height: 100%;
+}
+
 .MobileSimulator-phone {
   position: relative;
   width: 320px;
@@ -42,27 +46,25 @@
   border: 5px solid #333;
 }
 
+/* positions it within the image */
+.MobileSimulator-safari:before {
+  content: 'swipe-right-for-cs.teachingsystemslab.org';
+  font-size: 12px;
+  position: relative;
+  top: 46px;
+}
+
 .MobileSimulator-safari {
   position: relative;
   height: 100%;
-  background: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .MobileSimulator-background {
   position: relative;
   height: 444px;
   overflow: scroll;
-}
-
-.MobileSimulator-safari:after {
-  content: 'swipe-right-for-cs.teachingsystemslab.org';
-  font-size: 12px;
-  position: relative;
-  top: -483px;
-}
-
-.MobileSimulator-bottom {
-  position: absolute;
-  bottom: 0;
-  left: 0;
 }

--- a/client/src/MobileSimulator.js
+++ b/client/src/MobileSimulator.js
@@ -44,7 +44,7 @@ class MobileSimulator extends Component {
 
   renderResponsiveFrame(isNotWide) {
     const {children} = this.props;
-    if (!isNotWide) return children;
+    if (!isNotWide) return <div className="MobileSimulator-not-wide Global-background-color">{children}</div>;
     
     const {animScale} = this.state;
     return (
@@ -61,7 +61,7 @@ class MobileSimulator extends Component {
                 onMouseDown={this.onMouseDown}
                 onMouseOut={this.onMouseUp}
                 onMouseUp={this.onMouseUp} />
-              <div className="MobileSimulator-background MobileSimulator-dragscroll">
+              <div className="MobileSimulator-background MobileSimulator-dragscroll Global-background-color">
                 {children}
               </div>
               <img

--- a/client/src/Swipeable.css
+++ b/client/src/Swipeable.css
@@ -3,6 +3,11 @@
   align-items: center;
 }
 
+.Swipeable-spring {
+  position: 'relative';
+  height: 100%;
+}
+
 .Swipeable-items {
   display: flex;
   justify-content: space-between;

--- a/client/src/Swipeable.js
+++ b/client/src/Swipeable.js
@@ -27,7 +27,8 @@ class Swipeable extends Component {
     return (
       <div className="Swipeable" style={{height: height}}>
         <Animated.div
-          style={{position: 'relative', top: animTop}}>
+          className="Swipeable-spring"
+          style={{top: animTop}}>
           {this.renderSwipeable()}
         </Animated.div>
       </div>

--- a/client/src/Title.css
+++ b/client/src/Title.css
@@ -10,7 +10,7 @@
 }
 
 .Title-intro {
-  font-size: 600%;
+  font-size: 400%;
   text-align: center;
   display: flex;
   flex-direction: column;

--- a/client/src/Turn.css
+++ b/client/src/Turn.css
@@ -10,6 +10,7 @@
   align-items: center;
   justify-content: stretch;
   flex: 1;
+  margin: 10px;
 }
 
 .Turn-profile {

--- a/client/src/Turn.js
+++ b/client/src/Turn.js
@@ -38,16 +38,15 @@ class Turn extends Component {
     return (
       <div className="Turn">
         <div className="Turn-student">
-          <p>{profileName}</p>
           <img
-            height={230}
+            height={180}
             src={profileImageSrc}
             alt={profileName} />
           <div className="Turn-profile">{profileText}</div>
         </div>
         <Swipeable
           key={argumentText}
-          height={150}
+          height={120}
           onSwipeLeft={this.onSwipeLeft}
           onSwipeRight={this.onSwipeRight}>
           <div>{argumentText}</div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -12,3 +12,7 @@ button.button {
   align-self: center;
   background-color: #00ffff;
 }
+
+.Global-background-color {
+  background-color: #00ffff;
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -947,7 +947,7 @@ babel-register@^6.24.1, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1918,6 +1918,10 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
+dom-helpers@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
+
 dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -2529,7 +2533,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3844,6 +3848,10 @@ jsx-ast-utils@^2.0.0:
   dependencies:
     array-includes "^3.0.3"
 
+keycode@^2.1.7:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.9.tgz#964a23c54e4889405b4861a5c9f0480d45141dfa"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -5019,7 +5027,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5095,7 +5103,7 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-raf@^3.3.2:
+raf@^3.1.0, raf@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
@@ -5176,12 +5184,29 @@ react-error-overlay@^2.0.1:
     settle-promise "1.0.0"
     source-map "0.5.6"
 
+react-event-listener@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.5.0.tgz#d82105135573e187e3d900d18150a5882304b8d1"
+  dependencies:
+    babel-runtime "^6.26.0"
+    fbjs "^0.8.14"
+    prop-types "^15.5.10"
+    warning "^3.0.0"
+
 react-media@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/react-media/-/react-media-1.6.1.tgz#84e7986a92356b106dca026363f8f5c88054fe72"
   dependencies:
     json2mq "^0.2.0"
     prop-types "^15.5.10"
+
+react-motion@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  dependencies:
+    performance-now "^0.2.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
 
 react-scripts@1.0.13:
   version "1.0.13"
@@ -5224,6 +5249,35 @@ react-scripts@1.0.13:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "1.1.2"
+
+react-swipeable-views-core@^0.12.8:
+  version "0.12.8"
+  resolved "https://registry.yarnpkg.com/react-swipeable-views-core/-/react-swipeable-views-core-0.12.8.tgz#99460621e5a6da07fb482a25b151905ae7a797a9"
+  dependencies:
+    babel-runtime "^6.23.0"
+    warning "^3.0.0"
+
+react-swipeable-views-utils@^0.12.8:
+  version "0.12.8"
+  resolved "https://registry.yarnpkg.com/react-swipeable-views-utils/-/react-swipeable-views-utils-0.12.8.tgz#9483fc7dd370032f2f93ac44f2a2913d7c52aa41"
+  dependencies:
+    babel-runtime "^6.23.0"
+    fbjs "^0.8.4"
+    keycode "^2.1.7"
+    prop-types "^15.5.4"
+    react-event-listener "^0.5.0"
+    react-swipeable-views-core "^0.12.8"
+
+react-swipeable-views@^0.12.8:
+  version "0.12.8"
+  resolved "https://registry.yarnpkg.com/react-swipeable-views/-/react-swipeable-views-0.12.8.tgz#8541daab5881067e58281d1e6ff13815ae94ebf5"
+  dependencies:
+    babel-runtime "^6.23.0"
+    dom-helpers "^3.2.1"
+    prop-types "^15.5.4"
+    react-swipeable-views-core "^0.12.8"
+    react-swipeable-views-utils "^0.12.8"
+    warning "^3.0.0"
 
 "react@^15 || ^16", react@^15.6.1:
   version "15.6.2"
@@ -6306,6 +6360,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.10.0:
   version "0.10.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "yarn run dev",
     "test": "yarn run lint && cd client && yarn run test",
-    "heroku-prebuild": "cd client && YARN_PRODUCTION=false yarn install --frozen-lockfile",
+    "heroku-prebuild": "yarn install && cd client && YARN_PRODUCTION=false yarn install --frozen-lockfile",
     "heroku-postbuild": "cd client && yarn run build",
     "dev": "concurrently \"yarn run server\" \"yarn run client\"",
     "server": "node server/index.js",


### PR DESCRIPTION
Follow-on to https://github.com/mit-teaching-systems-lab/swipe-right-for-cs/pull/17, which regressed the background on desktop layouts.  This fixes that, and adjusts sizing specifically for iPhone 5 Safari.

# Desktop
![screen shot 2017-10-05 at 12 32 05 pm](https://user-images.githubusercontent.com/1056957/31238987-a0108270-a9c9-11e7-9a2b-09be14837333.png)
![screen shot 2017-10-05 at 12 32 02 pm](https://user-images.githubusercontent.com/1056957/31238986-a00c60b4-a9c9-11e7-8c81-868c3571d467.png)
![screen shot 2017-10-05 at 12 31 58 pm](https://user-images.githubusercontent.com/1056957/31238988-a01322fa-a9c9-11e7-96ae-28fe050df6c5.png)


# Mobile, sized to iPhone 5 Safari (444px height)
![screen shot 2017-10-05 at 12 32 20 pm](https://user-images.githubusercontent.com/1056957/31238979-9b0e473a-a9c9-11e7-9228-c7475d5993cc.png)
![screen shot 2017-10-05 at 12 32 17 pm](https://user-images.githubusercontent.com/1056957/31238978-9b0bd374-a9c9-11e7-8cd8-bbd41ca4fb4d.png)
![screen shot 2017-10-05 at 12 32 15 pm](https://user-images.githubusercontent.com/1056957/31238980-9b1008b8-a9c9-11e7-84d3-26b5e616c38f.png)

