### PR TITLE
Add analyzer, import lodash by function to reduce size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,11 @@ typings/
 
 # testing
 /coverage
+/client/coverage
 
 # production
 /build
+/client/build
 
 # misc
 .DS_Store

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
     "jest-fetch-mock": "^1.2.1",
     "raf": "^3.3.2",
     "raw-loader": "^0.5.1",
-    "react-scripts": "1.0.13"
+    "react-scripts": "1.0.13",
+    "source-map-explorer": "^1.5.0"
   },
   "dependencies": {
     "animated": "^0.2.0",
@@ -31,7 +32,8 @@
     "eject": "react-scripts eject",
     "lint": "eslint --ext jsx --ext js -c .eslintrc src",
     "jest": "react-scripts test --env=jsdom",
-    "coverage": "react-scripts test --env=jsdom --coverage"
+    "coverage": "react-scripts test --env=jsdom --coverage",
+    "analyze": "yarn run build && source-map-explorer build/static/js/main.*"
   },
   "proxy": "http://localhost:4000"
 }

--- a/client/src/loaders/createProfiles.js
+++ b/client/src/loaders/createProfiles.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import __zip from 'lodash/zip';
+import __capitalize from 'lodash/capitalize';
 import renderTemplate from './renderTemplate.js';
 import HM1 from '../files/HM1.png';
 import HF1 from '../files/HF1.png';
@@ -33,13 +34,13 @@ function imageFor(label) {
 function createProfiles(profileTemplates, variants) {
   if (profileTemplates.length !== variants.length) return [];
 
-  return _.zip(profileTemplates, variants).map(([profileTemplate, variant]) => {
+  return __zip(profileTemplates, variants).map(([profileTemplate, variant]) => {
     return {
       profileName: variant.name,
       profileImageSrc: imageFor(variant.image_key),
       profileText: renderTemplate(profileTemplate.profile_template, {
         Name: variant.name,
-        He: _.capitalize(variant.he),
+        He: __capitalize(variant.he),
         he: variant.he,
         his: variant.his,
         him: variant.him

--- a/client/src/loaders/loadDataForCohort.js
+++ b/client/src/loaders/loadDataForCohort.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import __shuffle from 'lodash/shuffle';
+import __flatten from 'lodash/flatten';
 import parseCsvSync from 'csv-parse/lib/sync';
 import profileTemplatesFile from '../files/profileTemplates.csv';
 import sortedVariantsFile from '../files/sortedVariants.csv';
@@ -36,7 +37,7 @@ export function cohortAndStudents(workshopCode, profileTemplates, variants) {
   const rotatedVariants = rotatedVariantsForProfiles(cohortNumber, profileTemplates, variants);
 
   // Within a game, randomly shuffle the order of variants shown
-  const shuffledVariants = _.shuffle(rotatedVariants);
+  const shuffledVariants = __shuffle(rotatedVariants);
 
   // Create actual concrete student profiles
   const students = createProfiles(profileTemplates, shuffledVariants);
@@ -49,7 +50,7 @@ export function cohortAndStudents(workshopCode, profileTemplates, variants) {
 // cohorts see a consistent set of students, and the balancing depends on the number of cohorts,
 // number of profiles, and the order of the variants.
 export function rotatedVariantsForProfiles(cohortNumber, profileTemplates, variants) {
-  const cohortVariants = _.flatten([
+  const cohortVariants = __flatten([
     variants.slice(cohortNumber, variants.length),
     variants.slice(0, cohortNumber)
   ]);

--- a/client/src/loaders/renderTemplate.js
+++ b/client/src/loaders/renderTemplate.js
@@ -1,13 +1,13 @@
-import _ from 'lodash';
+import __escape from 'lodash/escape';
 
 // Evaluate a mustache-style template safely, in compliance with CSP
 function renderTemplate(message, data) {
   return message.replace(/\{\{([^}]+)}}/g, function(s, match) {
     var result = data;
-    _.each(match.trim().split('.'), function(propertyName) {
+    match.trim().split('.').forEach((propertyName) => {
       result = result[propertyName];
     });
-    return _.escape(result);
+    return __escape(result);
   });
 }
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1173,6 +1173,10 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.1.2.tgz#3e40b81663f81d2dd6596a4cb714a8dc16cfabe0"
+
 buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
@@ -1517,7 +1521,7 @@ content-type@~1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
+convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
@@ -1897,6 +1901,10 @@ dns-txt@^2.0.2:
   resolved "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6"
   dependencies:
     buffer-indexof "^1.0.0"
+
+docopt@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/docopt/-/docopt-0.6.2.tgz#b28e9e2220da5ec49f7ea5bb24a47787405eeb11"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -4423,6 +4431,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
+
 opn@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/opn/-/opn-4.0.2.tgz#7abc22e644dff63b0a96d5ab7f2790c0f01abc95"
@@ -5566,6 +5578,10 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.2.6:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
@@ -5784,6 +5800,19 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-map-explorer@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/source-map-explorer/-/source-map-explorer-1.5.0.tgz#654e2ba0db158fecfc99b9cefdf891b755b767d1"
+  dependencies:
+    btoa "^1.1.2"
+    convert-source-map "^1.1.1"
+    docopt "^0.6.2"
+    glob "^7.1.2"
+    open "0.0.5"
+    source-map "^0.5.1"
+    temp "^0.8.3"
+    underscore "^1.8.3"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -5794,7 +5823,7 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
+source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -6064,6 +6093,13 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
+
 test-exclude@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
@@ -6214,6 +6250,10 @@ uglifyjs-webpack-plugin@^0.4.6:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+underscore@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Importing single lodash functions, cutting production bundle size by ~60k.  This is still huge, added an analyzer to visualize build size too.

Before:
<img width="1227" alt="screen shot 2017-10-05 at 3 45 24 pm" src="https://user-images.githubusercontent.com/1056957/31249160-49cccc00-a9e4-11e7-8caa-79d1a4f0a7a7.png">

After:
<img width="1229" alt="screen shot 2017-10-05 at 3 45 13 pm" src="https://user-images.githubusercontent.com/1056957/31249159-49b2ec0e-a9e4-11e7-99ea-8091da879f55.png">
