### PR TITLE
Patch Storybook build bug and fix quote typo in consent

### DIFF
--- a/client/.storybook/.babelrc
+++ b/client/.storybook/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react-app"]
+}

--- a/client/src/ConsentPhase.js
+++ b/client/src/ConsentPhase.js
@@ -6,7 +6,7 @@ import './ConsentPhase.css';
 
 // Note that changes here may require IRB amendments.
 const fullConsentText = `
-Optionally, we'd" like to use your responses here for a joint research study between MIT and code.org.  We would like to compare the responses across participants.
+Optionally, we'd like to use your responses here for a joint research study between MIT and code.org.  We would like to compare the responses across participants.
 
 Your responses would be included in the research, along with data from your code.org profile.  All data you enter is stored securely and protected on a secure server on Google Drive, Amazon Web Services or Heroku.  If you consent, we will email you a copy of this form for your records.
 


### PR DESCRIPTION
Storybook doesn't seem to like the `module.exports` syntax in the `shared/data.js` file that's used across client and server, so this makes it babelify in a way that works.

Also fix an unrelated quote typo in the consent.