### PR TITLE
Allow skipping ahead

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -191,6 +191,7 @@ class App extends Component {
     return (
       <StudentsPhase
         students={students}
+        allowSkipAfter={5}
         onInteraction={this.onInteraction}
         onDone={() => this.setState({phase})} />
     );

--- a/client/src/Student.js
+++ b/client/src/Student.js
@@ -8,7 +8,6 @@ import {Interactions} from './shared/data.js';
 import './Student.css';
 
 
-
 // Render a student, and handle all interactions for swiping or typing
 // or working with that student.
 class Student extends Component {

--- a/client/src/StudentsPhase.css
+++ b/client/src/StudentsPhase.css
@@ -2,3 +2,10 @@
   flex: 1;
   display: flex;
 }
+
+.StudentsPhase-float {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+}

--- a/client/src/StudentsPhase.js
+++ b/client/src/StudentsPhase.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Student from './Student.js';
+import Float from './components/Float.js';
 import './StudentsPhase.css';
-
+import Tappable from './components/Tappable.js';
 
 // Show the phase where we're going through students.
 class StudentsPhase extends Component {
@@ -12,6 +13,7 @@ class StudentsPhase extends Component {
       studentsDone: 0
     };
     this.onDoneStudent = this.onDoneStudent.bind(this);
+    this.onFloatClicked = this.onFloatClicked.bind(this);
   }
 
   currentStudent() {
@@ -27,11 +29,17 @@ class StudentsPhase extends Component {
     this.setState({studentsDone});
   }
 
+  onFloatClicked() {
+    const {onDone} = this.props;
+    onDone();
+  }
+
   render() {
     const {onInteraction} = this.props;
     const student = this.currentStudent();
     return (
       <div className="StudentsPhase">
+        {this.renderFloat()}
         <Student
           key={student.profileName}
           {...student}
@@ -41,9 +49,30 @@ class StudentsPhase extends Component {
       </div>
     );
   }
+
+  renderFloat() {
+    const {studentsDone} = this.state;
+    const {allowSkipAfter} = this.props;
+    if (studentsDone < allowSkipAfter) return;
+
+    return (
+      <div className="StudentsPhase-float">
+        <Tappable
+          onClick={this.onFloatClicked}>
+          <Float style={{backgroundColor: 'rgb(38,100,157)'}}>
+            <svg fill="#ffffff" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+              <path d="M4 18l8.5-6L4 6v12zm9-12v12l8.5-6L13 6z"/>
+              <path d="M0 0h24v24H0z" fill="none"/>
+            </svg>
+          </Float>
+        </Tappable>
+      </div>
+    );
+  }
 }
 StudentsPhase.propTypes = {
   students: PropTypes.arrayOf(PropTypes.object).isRequired,
+  allowSkipAfter: PropTypes.number.isRequired,
   onInteraction: PropTypes.func.isRequired,
   onDone: PropTypes.func.isRequired
 };

--- a/client/src/StudentsPhase.story.js
+++ b/client/src/StudentsPhase.story.js
@@ -10,6 +10,16 @@ storiesOf('StudentsPhase', module) //eslint-disable-line no-undef
     return withFrameSwitcher(
       <StudentsPhase
         students={storybookStudents}
+        allowSkipAfter={5}
+        onInteraction={(action('onInteraction'))}
+        onDone={action('onDone')} />
+    );
+  })
+  .add('skip', () => {
+    return withFrameSwitcher(
+      <StudentsPhase
+        students={storybookStudents}
+        allowSkipAfter={0}
         onInteraction={(action('onInteraction'))}
         onDone={action('onDone')} />
     );

--- a/client/src/components/Float.css
+++ b/client/src/components/Float.css
@@ -1,0 +1,17 @@
+.Float {
+  border-radius: 50%;
+  font-size: 24px;
+  height: 56px;
+  margin: auto;
+  min-width: 56px;
+  width: 56px;
+  padding: 0;
+  overflow: hidden;
+  background: #eee;
+  box-shadow: 0 1px 1.5px 0 rgba(0,0,0,.12), 0 1px 1px 0 rgba(0,0,0,.24);
+  position: relative;
+  line-height: normal;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/client/src/components/Float.js
+++ b/client/src/components/Float.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import './Float.css';
+import PropTypes from 'prop-types';
+
+// A floating button, Material-style
+class Float extends React.Component {
+  render() {
+    const {children, style} = this.props;
+    return <div className="Float" style={style}>{children}</div>;
+  }
+}
+
+Float.propTypes = {
+  children: PropTypes.node.isRequired,
+  style: PropTypes.object
+};
+Float.defaultPropTypes = {
+  style: {}
+};
+
+export default Float;

--- a/client/src/components/Tappable.js
+++ b/client/src/components/Tappable.js
@@ -1,0 +1,78 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Animated from 'animated/lib/targets/react-dom';
+
+
+// A tappable opacity
+class Tappable extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      animScale: new Animated.Value(1.0)
+    };
+    this.onMouseDown = this.onMouseDown.bind(this);
+    this.onMouseUp = this.onMouseUp.bind(this);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  doAnimateTo(toValue, options = {}) {
+    const {animScale} = this.state;
+    const {onEnd} = options;
+    Animated.spring(animScale, {
+      toValue,
+      speed: 20
+    }).start(onEnd);
+  }
+
+  onMouseDown() {
+    this.doAnimateTo(0.2); // same as React Native TouchableOpacity
+  }
+
+  onMouseUp() {
+    this.doAnimateTo(1.0);
+  }
+
+  onClick() {
+    const {onClick} = this.props;
+    const {animScale} = this.state;
+    animScale.setValue(1.0);
+    onClick();
+  }
+
+  render() {
+    const {children, outerStyle, style, disabled} = this.props;
+    const {animScale} = this.state;
+
+    // Spring on touch
+    return (
+      <Animated.div
+        className="Tappable"
+        style={{...outerStyle, opacity: animScale}}>
+        {disabled
+          ? <div
+            className="Tappable-inner Tappable-disabled"
+            style={style}>{children}</div>
+          : <div
+            className="Tappable-inner"
+            style={style}
+            onMouseDown={this.onMouseDown}
+            onMouseUp={this.onMouseUp}
+            onMouseOut={this.onMouseUp}
+            onClick={this.onClick}>{children}</div>}
+      </Animated.div>
+    );
+  }
+}
+
+Tappable.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  style: PropTypes.object,
+  outerStyle: PropTypes.object
+};
+Tappable.defaultProps = {
+  style: {}
+};
+
+export default Tappable;

--- a/client/src/components/TappableButton.js
+++ b/client/src/components/TappableButton.js
@@ -1,66 +1,25 @@
 import React, { Component } from 'react';
 import './TappableButton.css';
 import PropTypes from 'prop-types';
-import Animated from 'animated/lib/targets/react-dom';
+import Tappable from './Tappable.js';
 
 
 // A tappable button
 class TappableButton extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      animScale: new Animated.Value(1.0)
-    };
-    this.onMouseDown = this.onMouseDown.bind(this);
-    this.onMouseUp = this.onMouseUp.bind(this);
-    this.onClick = this.onClick.bind(this);
-  }
-
-  doAnimateTo(toValue, options = {}) {
-    const {animScale} = this.state;
-    const {onEnd} = options;
-    Animated.spring(animScale, {
-      toValue,
-      speed: 20
-    }).start(onEnd);
-  }
-
-  onMouseDown() {
-    this.doAnimateTo(0.2); // same as React Native TouchableOpacity
-  }
-
-  onMouseUp() {
-    this.doAnimateTo(1.0);
-  }
-
-  onClick() {
-    const {onClick} = this.props;
-    const {animScale} = this.state;
-    animScale.setValue(1.0);
-    onClick();
-  }
-
   render() {
+    const {onClick} = this.props;
     const {children, outerStyle, style, disabled} = this.props;
-    const {animScale} = this.state;
 
     // Spring on touch
     return (
-      <Animated.div
-        className="TappableButton"
-        style={{...outerStyle, opacity: animScale}}>
+      <Tappable
+        onClick={onClick}
+        outerStyle={outerStyle}
+        disable={disabled}>
         {disabled
-          ? <div
-            className="TappableButton-inner TappableButton-disabled"
-            style={style}>{children}</div>
-          : <div
-            className="TappableButton-inner"
-            style={style}
-            onMouseDown={this.onMouseDown}
-            onMouseUp={this.onMouseUp}
-            onMouseOut={this.onMouseUp}
-            onClick={this.onClick}>{children}</div>}
-      </Animated.div>
+          ? <div className="TappableButton-inner TappableButton-disabled" style={style}>{children}</div>
+          : <div className="TappableButton-inner" style={style}>{children}</div>}
+      </Tappable>
     );
   }
 }


### PR DESCRIPTION
This allows users to skip ahead after a certain minimum number of profiles.  It factors out `Tappable` from `TappableButton` and adds a `Float` UI component.

<img width="414" alt="screen shot 2017-10-16 at 11 19 27 pm" src="https://user-images.githubusercontent.com/1056957/31646870-979aa58c-b2d2-11e7-8381-9880c0fb10d9.png">
