### PR TITLE
Make sort order consistent and bucketed for first profiles, fix hashCode

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,7 +12,7 @@ import StudentsPhase from './StudentsPhase.js';
 import DiscussPhase from './DiscussPhase.js';
 import ReviewPhase from './ReviewPhase.js';
 import ThanksPhase from './ThanksPhase.js';
-import {loadDataForCohort, defaultConfig} from './loaders/loadDataForCohort.js';
+import {loadDataForCohort, defaultOptions} from './loaders/loadDataForCohort.js';
 
 
 // Describes the major phases of the whole game
@@ -34,7 +34,7 @@ class App extends Component {
     const query = queryString.parse(window.location.search);
     this.state = {
       isCodeOrg,
-      config: defaultConfig,
+      config: defaultOptions,
       sessionId: uuid.v4(),
       email: (isCodeOrg) ? query.email || '' : Session.unknownEmail(),
       workshopCode: (isCodeOrg) ? '' : 'demo-workshop-code',
@@ -73,7 +73,7 @@ class App extends Component {
 
   doFetchData() {
     const {workshopCode, config} = this.state;
-    loadDataForCohort(workshopCode, config.cohortOptions)
+    loadDataForCohort(workshopCode, config)
       .then(this.onDataLoaded)
       .catch(this.onDataError);
   }
@@ -190,10 +190,11 @@ class App extends Component {
 
   renderStudents(phase) {
     const {students, config} = this.state;
+    const {forcedProfileCount} = config;
     return (
       <StudentsPhase
         students={students}
-        allowSkipAfter={config.allowSkipAfter}
+        allowSkipAfter={forcedProfileCount}
         onInteraction={this.onInteraction}
         onDone={() => this.setState({phase})} />
     );

--- a/client/src/loaders/createProfiles.js
+++ b/client/src/loaders/createProfiles.js
@@ -36,7 +36,10 @@ export function imageFor(label) {
 //
 // Returns no students on input array length mismatch.
 export function createProfiles(profileTemplates, variants, argumentCount) {
-  if (profileTemplates.length !== variants.length) return [];
+  if (profileTemplates.length !== variants.length) {
+    console.warn(`createProfiles called with ${profileTemplates.length} profiles and ${variants.length} variants`); //eslint-disable-line no-console
+    return [];
+  }
 
   return __zip(profileTemplates, variants).map(([profileTemplate, variant]) => {
     const argumentTexts = __shuffle(argumentTextsFor(profileTemplate)).slice(0, argumentCount);

--- a/client/src/loaders/createProfiles.test.js
+++ b/client/src/loaders/createProfiles.test.js
@@ -1,11 +1,16 @@
 import fs from 'fs';
+import __range from 'lodash/range';
+import __uniqWith from 'lodash/uniqWith';
+import __isEqual from 'lodash/isEqual';
+import __sortBy from 'lodash/sortBy';
 import {createProfiles, imageFor} from './createProfiles.js';
 import parseCsvSync from 'csv-parse/lib/sync';
 
-it('returns no students when array lengths do not match', async () => {
-  const students = createProfiles([], [2], 1);
-  expect(students.length).toBe(0);
+it('warns when profiles and variants array lengths do not match', async () => {
+  expect(() => createProfiles([], [2], 1)).toThrow(new Error('createProfiles called with 0 profiles and 1 variants'));
+  expect(console.warn).toHaveBeenCalled(); // eslint-disable-line no-console
 });
+
 
 it('finds image files on disk matching sortedVariants.csv', () => {
   const sortedVariantsText = fs.readFileSync('./src/files/sortedVariants.csv').toString();
@@ -14,4 +19,89 @@ it('finds image files on disk matching sortedVariants.csv', () => {
   imageKeys.forEach((imageKey) => {
     expect([imageKey, imageFor(imageKey)]).not.toEqual([imageKey, undefined]);
   });
+});
+
+
+describe('with profileTemplates and variants', () => {
+  const profileTemplates = [{
+    "profile_key": 'journalist',
+    "profile_template": '{{Name}} hopes to apply for a journalism internship next summer and has been working hard at improving {{his}} writing all semester.',
+    "argument_1": 'It looks really good on your resume to take a computer science class, because it tells employers that you’re knowledgeable about a topic that’s really important. ',
+    "argument_2": 'Computer science creates so many new ways to express your creativity, whether it\'s generating images or videos,  creating interactive stories, or making new kinds of media altogether.',
+    "argument_3": 'Computing is ubiquitous. Learning about computer science will help you understand the world around you.',
+    "argument_4": 'The world needs active and informed citizens of the world, and computer science is now necessary knowledge in order to actively participate in a democracy. '
+  }, {
+    "profile_key": 'jokester',
+    "profile_template": '{{Name}} can always get the class cackling with {{his}} running commentary, but especially when {{he}} starts doing impersonations. Somehow {{he}}\'s able to do it in a way that everyone can laugh at it.',
+    "argument_1": 'You\'ll have so many career opportunities - high income, job flexibility, lots of options.',
+    "argument_2": 'There are real cultural and structural barriers that might make it hard to pursue computer science at the college level.  Getting started now in high school will be easier.',
+    "argument_3": 'Computing is part of designing new products, not just technical ones.  This isn\'t just gadgets and apps either, there are even wearable computers now.',
+    "argument_4": 'Learning CS can help you connect or build global communities that share your interests and passions.'
+  }, {
+    "profile_key": 'hardworker',
+    "profile_template": '{{Name}} is always studying and working diligently to be successful in {{his}} classes because {{he}} wants to be the first in {{his}} family to go to college.',
+    "argument_1": 'Understanding how to use computing is an important skill for leaders in most every field.',
+    "argument_2": 'There are real cultural and structural barriers that might make it hard to pursue computer science at the college level.  Getting started now in high school will be easier.',
+    "argument_3": 'Computing is part of designing new products, not just technical ones.  This isn\'t just gadgets and apps either, there are even wearable computers now.',
+    "argument_4": 'Computer science jobs are high-paying and high status, and can empower you to push back against current forms of oppression. '
+  }];
+
+  const variants = [
+    { "image_key": 'IM2', name: 'Raj', he: 'he', his: 'his', him: 'him' },
+    { "image_key": 'IF2', name: 'Sonali', he: 'she', his: 'her', him: 'her' },
+    { "image_key": 'WF2', name: 'Meredith', he: 'she', his: 'her', him: 'her' }
+  ];
+    
+
+  it('works', () => {
+    const profiles = createProfiles(profileTemplates, variants, 4);
+    expect(profiles.map(profile => profile.profileName)).toEqual([
+      'Raj',
+      'Sonali',
+      'Meredith'
+    ]);
+    expect(profiles.map(profile => profile.profileKey)).toEqual([
+      'journalist',
+      'jokester',
+      'hardworker'
+    ]);
+    expect(profiles.map(profile => profile.profileImageKey)).toEqual([
+      'IM2',
+      'IF2',
+      'WF2'
+    ]);
+  });
+});
+
+
+it('shuffles argumentTexts for a single profile', () => {
+  const profileTemplate = {
+    "profile_key": 'hardworker',
+    "profile_template": 'template',
+    "argument_1": 'a',
+    "argument_2": 'b',
+    "argument_3": 'c'
+  };
+  const variant = {
+    "image_key": 'IM2',
+    "name": 'Raj',
+    "he": 'he',
+    "his": 'his',
+    "him": 'him'
+  };
+  const runs = __range(0, 20).map(i => {
+    return createProfiles([profileTemplate], [variant], 3);
+  });
+
+  // same set
+  const uniqueSets = __uniqWith(runs.map(profiles => {
+    return __sortBy(profiles[0].argumentTexts);
+  }), __isEqual);
+  expect(uniqueSets.length).toEqual(1);
+
+  const uniqueOrders = __uniqWith(runs.map(profiles => {
+    return profiles[0].argumentTexts;
+  }), __isEqual);
+  expect(uniqueOrders.length).toBeGreaterThan(1);
+  expect(uniqueOrders.length).toBeLessThanOrEqual(runs.length);
 });

--- a/client/src/loaders/loadDataForCohort.test.js
+++ b/client/src/loaders/loadDataForCohort.test.js
@@ -1,9 +1,17 @@
 import fs from 'fs';
+import uuid from 'uuid';
 import __uniq from 'lodash/uniq';
+import __uniqWith from 'lodash/uniqWith';
+import __sortBy from 'lodash/sortBy';
+import __range from 'lodash/range';
+import __isEqual from 'lodash/isEqual';
+
 import {
   loadDataForCohort,
-  defaultConfig,
-  rotatedVariantsForProfiles
+  defaultOptions,
+  rotatedVariantsForProfiles,
+  consistentShuffleForCohort,
+  shuffleInBuckets
 } from './loadDataForCohort.js';
 
 function mockCsvFetches() {
@@ -14,24 +22,88 @@ function mockCsvFetches() {
 describe('loadDataForCohort', () => {
   it('has valid data files checked in', async () => {
     mockCsvFetches();
-    const {cohortNumber, students} = await loadDataForCohort('foo', defaultConfig);
-    expect(cohortNumber).toEqual(4);
+    const {cohortNumber, students} = await loadDataForCohort('foor', defaultOptions);
+    expect(cohortNumber).toEqual(3);
     expect(students.length).toEqual(10);
     expect(__uniq(students.map(s => s.argumentTexts.length))).toEqual([4]);
   });
 
-  it('rotates by cohortCode, in correct range', async () => {
-    mockCsvFetches();
-    expect((await loadDataForCohort('c', defaultConfig)).cohortNumber).toEqual(9);
-    expect((await loadDataForCohort('d', defaultConfig)).cohortNumber).toEqual(0);
-    expect((await loadDataForCohort('e', defaultConfig)).cohortNumber).toEqual(1);
+  it('buckets samples into cohortCodes that all fall in the correct range', async () => {
+    const runs = [];
+    for (var i = 0; i < 100; i++) {
+      mockCsvFetches();  
+      runs.push((await loadDataForCohort(uuid.v4(), defaultOptions)).cohortNumber);
+    }
+    expect(__uniq(runs).sort()).toEqual(__range(0, 10));
   });
-  
-  it('rotates by cohortCode, no negatives', async () => {
-    mockCsvFetches();
-    expect((await loadDataForCohort('abcdef', defaultConfig)).cohortNumber).toEqual(9);
-    expect((await loadDataForCohort('abcdee', defaultConfig)).cohortNumber).toEqual(0);
-    expect((await loadDataForCohort('abcded', defaultConfig)).cohortNumber).toEqual(1);
+});
+
+describe('createProfilesForCohort', () => {
+  describe('with random samples of cohortCodes', async () => {
+    it('uses consistent profileName and ordering', async () => {
+      // run samples
+      const runs = [];
+      for (var i = 0; i < 100; i++) {
+        mockCsvFetches();
+        runs.push(await loadDataForCohort(uuid.v4(), defaultOptions));
+      }
+
+      // Ensure all runs have the same profileNames
+      const uniqueRunsByName = __uniqWith(runs.map(run => {
+        const profileNames = run.students.map(student => student.profileName);
+        return __sortBy(profileNames);
+      }), __isEqual);
+      expect(uniqueRunsByName.length).toEqual(1);
+
+      // Ensure all runs have the same profileKeys
+      const uniqueRunsByKey = __uniqWith(runs.map(run => {
+        const profileKeys = run.students.map(student => student.profileKey);
+        return __sortBy(profileKeys);
+      }), __isEqual);
+      expect(uniqueRunsByKey.length).toEqual(1);
+    });
+  });
+});
+
+describe('shuffleInBuckets', () => {
+  const input = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+
+  // This uses an input list, and runs through each midpoint, 
+  // checking that the shuffling is done correctly.
+  it('shuffles them correctly at various midpoints', () => {
+    __range(0, 11).forEach(cohortNumber => {
+      __range(0, input.length).forEach(midpoint => {
+        const runs = __range(0, 20).map(i => {
+          const shuffled = shuffleInBuckets(input, midpoint, cohortNumber);
+          return {
+            left: shuffled.slice(0, midpoint),
+            right: shuffled.slice(midpoint)
+          };
+        });
+
+        // Check that shuffling happened according to partitions
+        // and that there are different combinations.
+        const lefts = __uniqWith(runs.map(run => run.left), __isEqual);
+        const rights = __uniqWith(runs.map(run => run.right), __isEqual);
+        expect(rights.length).toBeGreaterThan(0);
+        expect(lefts.length).toBeGreaterThan(0);
+
+        // Ensure that they all have the same set
+        const leftSets = __uniqWith(runs.map(run => __sortBy(run.left)), __isEqual);
+        const rightSets = __uniqWith(runs.map(run => __sortBy(run.right)), __isEqual);
+        expect(leftSets.length).toEqual(1);
+        expect(rightSets.length).toEqual(1);
+        expect(leftSets[0].concat(rightSets[0])).toEqual(input);
+      });
+    });
+  });
+
+  it('is deterministic for a cohortNumber', () => {
+    __range(0, 11).forEach(cohortNumber => {
+      const first = shuffleInBuckets(input, 5, cohortNumber);
+      const second = shuffleInBuckets(input, 5, cohortNumber);
+      expect(first).toEqual(second);
+    });
   });
 });
 
@@ -42,5 +114,13 @@ describe('rotatedVariantsForProfiles', () => {
     expect(rotatedVariantsForProfiles(0, profiles, variants)).toEqual(['x','y']);
     expect(rotatedVariantsForProfiles(1, profiles, variants)).toEqual(['y','z']);
     expect(rotatedVariantsForProfiles(2, profiles, variants)).toEqual(['z','x']);
+  });
+});
+
+describe('consistentShuffleForCohort', () => {
+  it('is consistent on subsequent calls', () => {
+    const first = consistentShuffleForCohort([4,32,5,9], 0);
+    const second = consistentShuffleForCohort([4,32,5,9], 0);
+    expect(first).toEqual(second);
   });
 });

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -17,3 +17,7 @@ window.matchMedia = window.matchMedia || function() {
     removeListener: function() {}
   };
 };
+
+// Make console.warn and error fail tests
+console.error = jest.fn(warn => { throw new Error(warn); }); //eslint-disable-line no-console
+console.warn = jest.fn(warn => { throw new Error(warn); }); //eslint-disable-line no-console

--- a/client/src/shared/data.js
+++ b/client/src/shared/data.js
@@ -139,18 +139,10 @@ const Log = {
   }
 };
 
-// For hashing a string to an integer
-// from https://docs.oracle.com/javase/7/docs/api/java/lang/String.html
+// For hashing a string to a unsigned 32-bit integer
 function hashCode(str){
-  var value = 0;
-  var power = 1;
-  var length = str.length;
-  for (var i = 0; i < length; i++) {
-    power = Math.pow(31, length - 1 - i);
-    value = value + (str.charCodeAt(i)) * power;
-    value = value & value; // Convert to 32bit integer
-  }
-  return value;
+  const md5 = crypto.createHash('md5').update(str).digest('hex');
+  return parseInt(md5.slice(-8), 16);
 }
 
 // For hashing a string to a string to obfuscate (insecurely)

--- a/client/src/shared/data.test.js
+++ b/client/src/shared/data.test.js
@@ -4,8 +4,10 @@ import {
 
 describe('hashCode', () => {
   it('works', async () => {
-    expect(hashCode('a')).toEqual(97);
-    expect(hashCode('abcde')).toEqual(92599395);
-    expect(hashCode('abcdef')).toEqual(-1424385949);
+    expect(hashCode('a')).toEqual(1769416289);
+    expect(hashCode('abcde')).toEqual(2245310342);
+    expect(hashCode('abcdef')).toEqual(2350159758);
+    expect(hashCode('{"item":5,"cohortNumber":1}')).toEqual(1186745993);
+    expect(hashCode('{"item":9,"cohortNumber":1}')).toEqual(3095721868);
   });
 });


### PR DESCRIPTION
This updates the experimental design, shuffling profiles in two buckets.  The first bucket of required profiles are the same order.  Also replaces `hashCode` implementation (which isn't used for anything durable) and adds a bunch of tests.