### PR TITLE
Add width: 100% everywhere for IE11

### DIFF
--- a/client/src/DiscussPhase.css
+++ b/client/src/DiscussPhase.css
@@ -1,5 +1,6 @@
 .DiscussPhase {
   flex: 1;
+  width: 100%;
 }
 
 .DiscussPhase-content {

--- a/client/src/IntroductionPhase.css
+++ b/client/src/IntroductionPhase.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  width: 100%;
 }
 
 .IntroductionPhase-header {

--- a/client/src/ReviewPhaseView.css
+++ b/client/src/ReviewPhaseView.css
@@ -1,5 +1,6 @@
 .ReviewPhaseView {
   flex: 1;
+  width: 100%;
 }
 
 .ReviewPhaseView-content {

--- a/client/src/Student.css
+++ b/client/src/Student.css
@@ -9,6 +9,7 @@
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
+  width: 100%;
 }
 
 .Student-choices {

--- a/client/src/StudentProfile.css
+++ b/client/src/StudentProfile.css
@@ -19,4 +19,5 @@
   text-align: center;
   margin: 10px;
   height: 100px;
+  width: 100%;
 }

--- a/client/src/StudentsPhase.css
+++ b/client/src/StudentsPhase.css
@@ -1,6 +1,7 @@
 .StudentsPhase {
   flex: 1;
   display: flex;
+  width: 100%;
 }
 
 .StudentsPhase-float {

--- a/client/src/ThanksPhase.css
+++ b/client/src/ThanksPhase.css
@@ -1,5 +1,6 @@
 .ThanksPhase {
   flex: 1;
+  width: 100%;
 }
 
 .ThanksPhase-content {

--- a/client/src/Title.css
+++ b/client/src/Title.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
 }
 
 .Title-intro {
@@ -12,6 +13,7 @@
   margin-top: 60px;
   display: flex;
   text-align: center;
+  width: 100%;
 }
 
 .Title-logo {

--- a/client/src/WorkshopCode.css
+++ b/client/src/WorkshopCode.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
 }
 
 .WorkshopCode-intro {
@@ -12,6 +13,7 @@
   margin-top: 60px;
   display: flex;
   text-align: center;
+  width: 100%;
 }
 
 .WorkshopCode-form {

--- a/client/src/components/MobileSimulator.css
+++ b/client/src/components/MobileSimulator.css
@@ -71,5 +71,6 @@
   height: 444px;
   width: 100%;
   overflow-y: auto;
+  -ms-overflow-style: none;
   display: flex;
 }


### PR DESCRIPTION
This fixes IE11 layout and scrollbars.

Before:
<img width="409" alt="screen shot 2017-10-18 at 10 46 16 am" src="https://user-images.githubusercontent.com/1056957/31725184-b53884fe-b3f1-11e7-8777-c12c5cd2d31b.png">

After:
<img width="430" alt="screen shot 2017-10-18 at 10 46 23 am" src="https://user-images.githubusercontent.com/1056957/31725183-b52d5f52-b3f1-11e7-9e78-4e033da33e25.png">
<img width="426" alt="screen shot 2017-10-18 at 10 46 07 am" src="https://user-images.githubusercontent.com/1056957/31725187-b6860d4a-b3f1-11e7-8639-4453a6535b07.png">
