### PR TITLE
Force uppercase workshop codes

### DIFF
--- a/client/src/WorkshopCode.js
+++ b/client/src/WorkshopCode.js
@@ -47,8 +47,9 @@ class WorkshopCode extends Component {
     this.setState({ isWarningDismissed: true });
   }
 
+
   onChangeWorkshopCode(event) {
-    const workshopCode = event.target.value;
+    const workshopCode = event.target.value.toUpperCase(); // case matters
     this.setState({workshopCode});
   }
 

--- a/client/src/loaders/loadDataForCohort.js
+++ b/client/src/loaders/loadDataForCohort.js
@@ -47,7 +47,8 @@ export function cohortCreateAndShuffle(workshopCode, profileTemplates, variants,
   } = __defaults({}, options, defaultOptions);
 
   // Bucket into cohort, and create profiles for cohort
-  const cohortNumber = Math.abs(hashCode(workshopCode)) % cohortCount;
+  // Workshop codes are case-insensitive.
+  const cohortNumber = Math.abs(hashCode(workshopCode.toUpperCase())) % cohortCount;
   const studentProfiles = createProfilesForCohort(cohortNumber, profileTemplates, variants, {
     maxProfileCount,
     argumentCount


### PR DESCRIPTION
In the first sessions, folks in the same workshop used different cases for the workshop code, and so got hashed into different cohorts.