### PR TITLE
Fix up how tmp data for InteractionsView.story.js is loaded

### DIFF
--- a/client/src/research/InteractionsView.js
+++ b/client/src/research/InteractionsView.js
@@ -1,15 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import db from '../../../tmp/swipe-right-db.json';
 import {InteractionTypes} from '../shared/data.js';
+
 
 // Render a list of logged user interactions
 class InteractionsView extends Component {
   render() {  
     // unpack!
     //filter out testing data
-
-    const interactions = db.interactions.filter(row =>{  
+    const interactions = this.props.interactions.filter(row =>{  
       if (row.session.workshopCode === 'foo') return false;
       if (row.session.workshopCode === 'demo') return false;
       if (row.session.workshopCode === 'code.org') return false;
@@ -29,13 +28,13 @@ class InteractionsView extends Component {
     return( 
       <div>
         {this.renderPercentSwipeRight(interactions)}
-        <table> {interactions.map(row =>{
+        <table>{interactions.map(row =>{
           return <tr key = {row.id}>
             <td> {row.id} </td>
             <td> {row.timestampz} </td>
             <td> {row.interaction.type} </td>        
           </tr>;
-        })} </table>
+        })}</table>
       </div>
     );
   }

--- a/client/src/research/InteractionsView.story.js
+++ b/client/src/research/InteractionsView.story.js
@@ -3,9 +3,12 @@ import { storiesOf } from '@storybook/react';
 import {withFrameSwitcher} from '../util/storybookFrames.js';
 import InteractionsView from './InteractionsView.js';
 
+
 storiesOf('InteractionsView', module) //eslint-disable-line no-undef
   .add('normal', () => {
+    const db = require('../../../tmp/swipe-right-db.json');
+    const {interactions} = db;
     return withFrameSwitcher(
-      <InteractionsView />
+      <InteractionsView interactions={interactions} />
     );
   });


### PR DESCRIPTION
This improves the initial strategy for loading temporary data into `InteractionsView.story.js` in https://github.com/mit-teaching-systems-lab/swipe-right-for-cs/pull/78, since the previous strategy fails tests when the temporary data isn't present.