### PR TITLE
Add React Router for routing to /login and /research and other pages

### DIFF
--- a/client/.storybook/config.js
+++ b/client/.storybook/config.js
@@ -11,6 +11,7 @@ function loadStories() {
   require('../src/ThanksPhase.story.js');
   require('../src/loaders/loadDataForCohort.story.js');
   require('../src/research/InteractionsView.story.js');
+  require('../src/research/LoginPage.story.js');
   // You can require as many stories as you need.
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,241 +1,32 @@
 import React, { Component } from 'react';
-import uuid from 'uuid';
-import __isEmpty from 'lodash/isEmpty';
-import queryString from 'query-string';
-import './App.css';
-import {Log, Session} from './shared/data.js';
-import {error} from './shared/log.js';
-import MobileSimulator from './components/MobileSimulator.js';
-import Lifecycle from './components/Lifecycle.js';
-import WorkshopCode from './WorkshopCode.js';
-import Title from './Title.js';
-import ConsentPhase from './ConsentPhase.js';
-import IntroductionPhase from './IntroductionPhase.js';
-import StudentsPhase from './StudentsPhase.js';
-import DiscussPhase from './DiscussPhase.js';
-import ReviewPhase from './ReviewPhase.js';
-import ThanksPhase from './ThanksPhase.js';
-import {loadDataForCohort, defaultOptions} from './loaders/loadDataForCohort.js';
+import {BrowserRouter, Route} from 'react-router-dom';
+import GamePage from './GamePage';
+import LoginPage from './research/LoginPage';
+import ResearchPage from './research/ResearchPage';
 
 
-// Describes the major phases of the whole game
-const Phases = {
-  WORKSHOP_CODE: 'WORKSHOP_CODE',
-  TITLE: 'TITLE',
-  CONSENT: 'CONSENT',
-  INTRODUCTION: 'INTRODUCTION',
-  STUDENTS: 'STUDENTS',
-  DISCUSS: 'DISCUSS',
-  REVIEW: 'REVIEW',
-  THANKS: 'THANKS'
-};
-
-
+// The main entry point for the app, routing to different pages.
 class App extends Component {
-  constructor(props) {
-    super(props);
-    const isCodeOrg = (window.location.pathname !== '/play');
-    const query = queryString.parse(window.location.search);
-    this.state = {
-      isCodeOrg,
-      config: defaultOptions,
-      sessionId: uuid.v4(),
-      identifier: (isCodeOrg)
-        ? query.cuid || Session.unknownIdentifier()
-        : Session.unknownIdentifier(),
-      workshopCode: ['DEMO', uuid.v4()].join(':'), // for code.org, set in initial screens
-      cohortNumber: null, // set when data is loaded, based on workhopCode
-      phase: (isCodeOrg) ? Phases.WORKSHOP_CODE : Phases.TITLE,
-      students: null,
-      logs: []
-    };
-    this.onDataLoaded = this.onDataLoaded.bind(this);
-    this.onDataError = this.onDataError.bind(this);
-    this.onInteraction = this.onInteraction.bind(this);
-    this.renderDemo = this.renderDemo.bind(this);
-    this.renderCodeOrg = this.renderCodeOrg.bind(this);
-  }
-
-  // Describe context of the game session
-  session() {
-    const {isCodeOrg, identifier, workshopCode, cohortNumber, sessionId} = this.state;
-    return Session.create({
-      isCodeOrg,
-      identifier,
-      workshopCode,
-      cohortNumber,
-      sessionId,
-      clientTimestampMs: new Date().getTime(),
-      location: window.location.toString()
-    });
-  }
-
-  shouldWarnAboutCodeStudio() {
-    const {identifier} = this.state;
-    return (
-      (identifier === Session.unknownIdentifier()) ||
-      (__isEmpty(identifier))
-    );
-  }
-
-  doFetchData() {
-    const {workshopCode, config} = this.state;
-    loadDataForCohort(workshopCode, config)
-      .then(this.onDataLoaded)
-      .catch(this.onDataError);
-  }
-
-  // Optimization
-  doPrefetchStudentImages(students) {
-    const imageUrls = students.map(s => s.profileImageSrc);
-    imageUrls.forEach(imageUrl => {
-      const image = new Image();
-      image.src = imageUrl;
-    });
-  }
-
-  // Log to the server
-  doLog(log) {
-    fetch('/api/log', {
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      method: 'POST',
-      body: JSON.stringify(log)
-    });
-  }
-
-  onWorkshopCodeDone(nextPhase, workshopCode) {
-    this.setState({workshopCode, phase: nextPhase});
-  }
-
-  onTitleDone(nextPhase) {
-    this.setState({phase: nextPhase});
-  }
-
-  onDataLoaded(loadedData) {
-    const {cohortNumber, students} = loadedData;
-    this.setState({cohortNumber, students});
-    this.doPrefetchStudentImages(students);
-  }
-
-  onDataError(err) {
-    error(err);
-  }
-
-  // Log the interaction, along with context about the session.
-  onInteraction(interaction) {
-    const {logs} = this.state;
-    const session = this.session();
-    const log = Log.create(session, interaction);
-    this.setState({ logs: logs.concat(log) });
-    this.doLog(log);
-  }
-
   render() {
-    const {isCodeOrg} = this.state;
     return (
-      <div className="App">
-        <MobileSimulator minWidth={800} minHeight={400}>
-          {isCodeOrg ? this.renderCodeOrg() : this.renderDemo()}
-        </MobileSimulator>
-      </div>
+      <BrowserRouter>
+        <div className="App">
+          <Route exact path="/research" component={ResearchPage} />
+          <Route exact path="/login" component={LoginPage} />
+          <Route exact path="/play" render={this.renderDemo} />
+          <Route exact path="/start" render={this.renderCodeOrg} />
+          <Route exact path="/" render={this.renderCodeOrg} />
+        </div>
+      </BrowserRouter>
     );
   }
 
-  // From code.org Code Studio, with identifier on query string
-  renderCodeOrg() {
-    const {phase, students} = this.state;
-    if (phase === Phases.WORKSHOP_CODE) return this.renderWorkshopCode(Phases.TITLE);
-    if (phase === Phases.TITLE) return this.renderTitle(Phases.CONSENT);
-    if (phase === Phases.CONSENT) return this.renderConsent(Phases.INTRODUCTION);
-    if (phase === Phases.INTRODUCTION) return this.renderIntroduction(Phases.STUDENTS);
-    if (!students) return this.renderLoading();
-    if (phase === Phases.STUDENTS) return this.renderStudents(Phases.DISCUSS);
-    if (phase === Phases.DISCUSS) return this.renderDiscuss(Phases.REVIEW);
-    if (phase === Phases.REVIEW) return this.renderReview(Phases.THANKS);
-    if (phase === Phases.THANKS) return this.renderThanks();
+  renderDemo(props) {
+    return <GamePage {...props} isCodeOrg={false} />;
   }
 
-  // Publicly open demo
-  renderDemo() {
-    const {phase, students} = this.state;
-    if (phase === Phases.TITLE) return this.renderTitle(Phases.INTRODUCTION);
-    if (phase === Phases.INTRODUCTION) return this.renderIntroduction(Phases.STUDENTS);
-    if (!students) return this.renderLoading();
-    if (phase === Phases.STUDENTS) return this.renderStudents(Phases.REVIEW);
-    if (phase === Phases.REVIEW) return this.renderReview(Phases.THANKS);
-    if (phase === Phases.THANKS) return this.renderThanks();
-  }
-
-  renderWorkshopCode(phase) {
-    return <WorkshopCode
-      shouldWarnAboutCodeStudio={this.shouldWarnAboutCodeStudio()}
-      onInteraction={this.onInteraction}
-      onDone={this.onWorkshopCodeDone.bind(this, phase)} />;
-  }
-
-  renderTitle(phase) {
-    return (
-      <Lifecycle componentWillMount={() => this.doFetchData()}>
-        <Title
-          onInteraction={this.onInteraction}
-          onDone={this.onTitleDone.bind(this, phase)} />
-      </Lifecycle>
-    );
-  }
-
-  renderConsent(phase) {
-    return <ConsentPhase
-      onInteraction={this.onInteraction}
-      onDone={() => this.setState({phase})} />;
-  }
-
-  renderIntroduction(phase) {
-    return <IntroductionPhase
-      onInteraction={this.onInteraction}
-      onDone={() => this.setState({phase})} />;
-  }
-
-  renderLoading() {
-    return <div>Loading...</div>;
-  }
-
-  renderStudents(phase) {
-    const {students, config} = this.state;
-    const {forcedProfileCount} = config;
-    return (
-      <StudentsPhase
-        students={students}
-        allowSkipAfter={forcedProfileCount}
-        onInteraction={this.onInteraction}
-        onDone={() => this.setState({phase})} />
-    );
-  }
-
-  renderDiscuss(phase) {
-    const {students} = this.state;
-    return <DiscussPhase
-      students={students}
-      onInteraction={this.onInteraction}
-      onDone={() => this.setState({phase})} />;
-  }
-
-  renderReview(phase) {
-    const {students, workshopCode} = this.state;
-    return <ReviewPhase
-      workshopCode={workshopCode}
-      students={students}
-      onInteraction={this.onInteraction}
-      onDone={() => this.setState({phase})} />;
-  }
-
-  renderThanks(phase) {
-    const {logs} = this.state;
-    return <ThanksPhase
-      logs={logs}
-      onInteraction={this.onInteraction} />;
+  renderCodeOrg(props) {
+    return <GamePage {...props} isCodeOrg={true} />;
   }
 }
 

--- a/client/src/GamePage.js
+++ b/client/src/GamePage.js
@@ -1,0 +1,244 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import uuid from 'uuid';
+import __isEmpty from 'lodash/isEmpty';
+import queryString from 'query-string';
+import './App.css';
+import {Log, Session} from './shared/data.js';
+import {error} from './shared/log.js';
+import MobileSimulator from './components/MobileSimulator.js';
+import Lifecycle from './components/Lifecycle.js';
+import WorkshopCode from './WorkshopCode.js';
+import Title from './Title.js';
+import ConsentPhase from './ConsentPhase.js';
+import IntroductionPhase from './IntroductionPhase.js';
+import StudentsPhase from './StudentsPhase.js';
+import DiscussPhase from './DiscussPhase.js';
+import ReviewPhase from './ReviewPhase.js';
+import ThanksPhase from './ThanksPhase.js';
+import {loadDataForCohort, defaultOptions} from './loaders/loadDataForCohort.js';
+
+
+// Describes the major phases of the whole game
+const Phases = {
+  WORKSHOP_CODE: 'WORKSHOP_CODE',
+  TITLE: 'TITLE',
+  CONSENT: 'CONSENT',
+  INTRODUCTION: 'INTRODUCTION',
+  STUDENTS: 'STUDENTS',
+  DISCUSS: 'DISCUSS',
+  REVIEW: 'REVIEW',
+  THANKS: 'THANKS'
+};
+
+
+class GamePage extends Component {
+  constructor(props) {
+    super(props);
+    const isCodeOrg = props.isCodeOrg;
+    const query = queryString.parse(window.location.search);
+    this.state = {
+      isCodeOrg,
+      config: defaultOptions,
+      sessionId: uuid.v4(),
+      identifier: (isCodeOrg)
+        ? query.cuid || Session.unknownIdentifier()
+        : Session.unknownIdentifier(),
+      workshopCode: ['DEMO', uuid.v4()].join(':'), // for code.org, set in initial screens
+      cohortNumber: null, // set when data is loaded, based on workhopCode
+      phase: (isCodeOrg) ? Phases.WORKSHOP_CODE : Phases.TITLE,
+      students: null,
+      logs: []
+    };
+    this.onDataLoaded = this.onDataLoaded.bind(this);
+    this.onDataError = this.onDataError.bind(this);
+    this.onInteraction = this.onInteraction.bind(this);
+    this.renderDemo = this.renderDemo.bind(this);
+    this.renderCodeOrg = this.renderCodeOrg.bind(this);
+  }
+
+  // Describe context of the game session
+  session() {
+    const {isCodeOrg, identifier, workshopCode, cohortNumber, sessionId} = this.state;
+    return Session.create({
+      isCodeOrg,
+      identifier,
+      workshopCode,
+      cohortNumber,
+      sessionId,
+      clientTimestampMs: new Date().getTime(),
+      location: window.location.toString()
+    });
+  }
+
+  shouldWarnAboutCodeStudio() {
+    const {identifier} = this.state;
+    return (
+      (identifier === Session.unknownIdentifier()) ||
+      (__isEmpty(identifier))
+    );
+  }
+
+  doFetchData() {
+    const {workshopCode, config} = this.state;
+    loadDataForCohort(workshopCode, config)
+      .then(this.onDataLoaded)
+      .catch(this.onDataError);
+  }
+
+  // Optimization
+  doPrefetchStudentImages(students) {
+    const imageUrls = students.map(s => s.profileImageSrc);
+    imageUrls.forEach(imageUrl => {
+      const image = new Image();
+      image.src = imageUrl;
+    });
+  }
+
+  // Log to the server
+  doLog(log) {
+    fetch('/api/log', {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST',
+      body: JSON.stringify(log)
+    });
+  }
+
+  onWorkshopCodeDone(nextPhase, workshopCode) {
+    this.setState({workshopCode, phase: nextPhase});
+  }
+
+  onTitleDone(nextPhase) {
+    this.setState({phase: nextPhase});
+  }
+
+  onDataLoaded(loadedData) {
+    const {cohortNumber, students} = loadedData;
+    this.setState({cohortNumber, students});
+    this.doPrefetchStudentImages(students);
+  }
+
+  onDataError(err) {
+    error(err);
+  }
+
+  // Log the interaction, along with context about the session.
+  onInteraction(interaction) {
+    const {logs} = this.state;
+    const session = this.session();
+    const log = Log.create(session, interaction);
+    this.setState({ logs: logs.concat(log) });
+    this.doLog(log);
+  }
+
+  render() {
+    const {isCodeOrg} = this.state;
+    return (
+      <MobileSimulator minWidth={800} minHeight={400}>
+        {isCodeOrg ? this.renderCodeOrg() : this.renderDemo()}
+      </MobileSimulator>
+    );
+  }
+
+  // From code.org Code Studio, with identifier on query string
+  renderCodeOrg() {
+    const {phase, students} = this.state;
+    if (phase === Phases.WORKSHOP_CODE) return this.renderWorkshopCode(Phases.TITLE);
+    if (phase === Phases.TITLE) return this.renderTitle(Phases.CONSENT);
+    if (phase === Phases.CONSENT) return this.renderConsent(Phases.INTRODUCTION);
+    if (phase === Phases.INTRODUCTION) return this.renderIntroduction(Phases.STUDENTS);
+    if (!students) return this.renderLoading();
+    if (phase === Phases.STUDENTS) return this.renderStudents(Phases.DISCUSS);
+    if (phase === Phases.DISCUSS) return this.renderDiscuss(Phases.REVIEW);
+    if (phase === Phases.REVIEW) return this.renderReview(Phases.THANKS);
+    if (phase === Phases.THANKS) return this.renderThanks();
+  }
+
+  // Publicly open demo
+  renderDemo() {
+    const {phase, students} = this.state;
+    if (phase === Phases.TITLE) return this.renderTitle(Phases.INTRODUCTION);
+    if (phase === Phases.INTRODUCTION) return this.renderIntroduction(Phases.STUDENTS);
+    if (!students) return this.renderLoading();
+    if (phase === Phases.STUDENTS) return this.renderStudents(Phases.REVIEW);
+    if (phase === Phases.REVIEW) return this.renderReview(Phases.THANKS);
+    if (phase === Phases.THANKS) return this.renderThanks();
+  }
+
+  renderWorkshopCode(phase) {
+    return <WorkshopCode
+      shouldWarnAboutCodeStudio={this.shouldWarnAboutCodeStudio()}
+      onInteraction={this.onInteraction}
+      onDone={this.onWorkshopCodeDone.bind(this, phase)} />;
+  }
+
+  renderTitle(phase) {
+    return (
+      <Lifecycle componentWillMount={() => this.doFetchData()}>
+        <Title
+          onInteraction={this.onInteraction}
+          onDone={this.onTitleDone.bind(this, phase)} />
+      </Lifecycle>
+    );
+  }
+
+  renderConsent(phase) {
+    return <ConsentPhase
+      onInteraction={this.onInteraction}
+      onDone={() => this.setState({phase})} />;
+  }
+
+  renderIntroduction(phase) {
+    return <IntroductionPhase
+      onInteraction={this.onInteraction}
+      onDone={() => this.setState({phase})} />;
+  }
+
+  renderLoading() {
+    return <div>Loading...</div>;
+  }
+
+  renderStudents(phase) {
+    const {students, config} = this.state;
+    const {forcedProfileCount} = config;
+    return (
+      <StudentsPhase
+        students={students}
+        allowSkipAfter={forcedProfileCount}
+        onInteraction={this.onInteraction}
+        onDone={() => this.setState({phase})} />
+    );
+  }
+
+  renderDiscuss(phase) {
+    const {students} = this.state;
+    return <DiscussPhase
+      students={students}
+      onInteraction={this.onInteraction}
+      onDone={() => this.setState({phase})} />;
+  }
+
+  renderReview(phase) {
+    const {students, workshopCode} = this.state;
+    return <ReviewPhase
+      workshopCode={workshopCode}
+      students={students}
+      onInteraction={this.onInteraction}
+      onDone={() => this.setState({phase})} />;
+  }
+
+  renderThanks(phase) {
+    const {logs} = this.state;
+    return <ThanksPhase
+      logs={logs}
+      onInteraction={this.onInteraction} />;
+  }
+}
+GamePage.propTypes = {
+  isCodeOrg: PropTypes.bool.isRequired
+};
+
+export default GamePage;

--- a/client/src/GamePage.test.js
+++ b/client/src/GamePage.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import fs from 'fs';
+import GamePage from './GamePage';
+
+
+it('renders without crashing for Code.org entryway', async () => {
+  fetch.mockResponseOnce(fs.readFileSync('./src/files/profileTemplates.csv').toString());
+  fetch.mockResponseOnce(fs.readFileSync('./src/files/sortedVariants.csv').toString());
+  const div = document.createElement('div');
+  await ReactDOM.render(<GamePage isCodeOrg={true} />, div);
+});
+
+it('renders without crashing for demo', async () => {
+  fetch.mockResponseOnce(fs.readFileSync('./src/files/profileTemplates.csv').toString());
+  fetch.mockResponseOnce(fs.readFileSync('./src/files/sortedVariants.csv').toString());
+  const div = document.createElement('div');
+  await ReactDOM.render(<GamePage isCodeOrg={false} />, div);
+});

--- a/client/src/loaders/loadDataForCohort.story.js
+++ b/client/src/loaders/loadDataForCohort.story.js
@@ -8,7 +8,7 @@ import Select from '../util/Select.js';
 import StudentProfile from '../StudentProfile.js';
 
 
-storiesOf('loadDataForCohort', module) //eslint-disable-line no-undef
+storiesOf('Research/loadDataForCohort', module) //eslint-disable-line no-undef
   .add('normal', () => {
     // render across multiple workshop codes in columns
     const workshopCodes = [

--- a/client/src/research/InteractionsView.story.js
+++ b/client/src/research/InteractionsView.story.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import InteractionsView from './InteractionsView.js';
 
 
-storiesOf('InteractionsView', module) //eslint-disable-line no-undef
+storiesOf('Research/InteractionsView', module) //eslint-disable-line no-undef
   .add('normal', () => {
     const db = require('../../../tmp/swipe-right-db.json');
     const {interactions} = db;

--- a/client/src/research/LoginPage.js
+++ b/client/src/research/LoginPage.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react';
+
+
+// The page for users to login for accessing research data.
+class LoginPage extends Component {
+  render() {
+    return <div>login please!</div>;
+  }
+}
+
+export default LoginPage;

--- a/client/src/research/LoginPage.story.js
+++ b/client/src/research/LoginPage.story.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import LoginPage from './LoginPage.js';
+
+storiesOf('Research/LoginPage', module) //eslint-disable-line no-undef
+  .add('normal', () => {
+    return <LoginPage />;
+  });

--- a/client/src/research/LoginPage.test.js
+++ b/client/src/research/LoginPage.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import LoginPage from './LoginPage';
+
+
+it('renders without crashing', async () => {
+  const div = document.createElement('div');
+  await ReactDOM.render(<LoginPage />, div);
+});

--- a/client/src/research/ResearchPage.js
+++ b/client/src/research/ResearchPage.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+import Interactions from './Interactions';
+
+
+// The page for logged-in user to access research data.
+class ResearchPage extends Component {
+  render() {
+    return <Interactions />;
+  }
+}
+
+export default ResearchPage;


### PR DESCRIPTION
This adds React Router, and moves the code that was in `App` into `GamePage`.  `App` now handles routing between different pages, so that we can more easily add in routing for new pages we're adding for authentication/authorization and for access to pages to access research data and analysis.