### PR TITLE
Patch keyboard navigation

### DIFF
--- a/client/src/components/Swipeable.js
+++ b/client/src/components/Swipeable.js
@@ -4,8 +4,9 @@ import './Swipeable.css';
 import PropTypes from 'prop-types';
 import Bounceable from './Bounceable.js';
 import SwipeableViews from 'react-swipeable-views';
-import {bindKeyboard} from 'react-swipeable-views-utils';
-const BindKeyboardSwipeableViews = bindKeyboard(SwipeableViews);
+import keycode from 'keycode';
+import EventListener from 'react-event-listener';
+
 
 const styles = {
   fullSize: {
@@ -25,6 +26,7 @@ class Swipeable extends Component {
     };
     this.onChangeIndex = this.onChangeIndex.bind(this);
     this.onTransitionEnd = this.onTransitionEnd.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
   }
 
   onChangeIndex(index) {
@@ -36,6 +38,17 @@ class Swipeable extends Component {
     const {onSwipeLeft, onSwipeRight} = this.props;
     if (onSwipeRight && swipeIndex === 0) return onSwipeRight();
     if (swipeIndex === 2) return onSwipeLeft();
+  }
+
+  // This changes the state, which triggers render and that
+  // leads to the animated transition, which triggers onTransitionEnd.
+  onKeyDown(event) {
+    const {swipeIndex} = this.state;
+    if (swipeIndex !== 1) return;
+
+    const keyName = keycode(event);
+    if (keyName === 'left') return this.onChangeIndex(2);
+    if (keyName === 'right') return this.onChangeIndex(0);
   }
 
   render() {
@@ -68,18 +81,20 @@ class Swipeable extends Component {
       onSwipeLeft && <div key="right" className="Swipeable-right">&nbsp;</div>
     ]);
     return (
-      <BindKeyboardSwipeableViews
-        resistance={true}
-        className="Swipeable-views"
-        enableMouseEvents={true}
-        springConfig={springConfig}
-        slideStyle={styles.fullSize} 
-        containerStyle={styles.fullSize}
-        index={swipeIndex}
-        onChangeIndex={this.onChangeIndex}
-        onTransitionEnd={this.onTransitionEnd}>
-        {elements}
-      </BindKeyboardSwipeableViews>
+      <EventListener target="window" onKeyDown={this.onKeyDown}>
+        <SwipeableViews
+          resistance={true}
+          className="Swipeable-views"
+          enableMouseEvents={true}
+          springConfig={springConfig}
+          slideStyle={styles.fullSize} 
+          containerStyle={styles.fullSize}
+          index={swipeIndex}
+          onChangeIndex={this.onChangeIndex}
+          onTransitionEnd={this.onTransitionEnd}>
+          {elements}
+        </SwipeableViews>
+      </EventListener>
     );
   }
 }

--- a/client/src/components/Swipeable.test.js
+++ b/client/src/components/Swipeable.test.js
@@ -12,6 +12,13 @@ function testProps(props = {}) {
   };
 }
 
+function renderTestCase(moreProps = {}) {
+  const div = document.createElement('div');
+  const props = testProps(moreProps);
+  const instance = ReactDOM.render(<Swipeable {...props} />, div); // eslint-disable-line react/no-render-return-value
+  return {div, props, instance};
+}
+
 it('renders without crashing', async () => {
   const div = document.createElement('div');
   const props = testProps();
@@ -19,13 +26,41 @@ it('renders without crashing', async () => {
 });
 
 it('records interactions correctly', async () => {
-  const div = document.createElement('div');
-  const props = testProps();
-  const instance = ReactDOM.render(<Swipeable {...props} />, div); // eslint-disable-line react/no-render-return-value
-
+  const {props, instance} = renderTestCase();
   expect(instance.state.swipeIndex).toEqual(1);
+
   instance.onChangeIndex(0);
   instance.onTransitionEnd();
   expect(props.onSwipeLeft).not.toHaveBeenCalled();
   expect(props.onSwipeRight).toHaveBeenCalled();
+});
+
+// We can't directly test that the swipe prop functions are called,
+// since they're trigged by the `onTransitionEnd` methods which rely on
+// CSS transition events that aren't supported in the test environment.
+//
+// jsdom doesn't support the TransitionEnd property.  SwipeableViews
+// uses 'dom-helpers' to map event names to vendor-aware names, and
+// it can't find the transition event so SwipeableViews ends up
+// calling addEventListener with an undefined event name.
+describe('handles keyboard navigation correctly', () => {
+  it('on left arrow', async () => {
+    const {instance} = renderTestCase();
+    instance.onKeyDown({which: 37 });
+    expect(instance.state.swipeIndex).toEqual(2);
+  });
+
+  it('on right arrow', async () => {
+    const {instance} = renderTestCase();
+    instance.onKeyDown({which: 39 });
+    expect(instance.state.swipeIndex).toEqual(0);
+  });
+
+  it('ignores after initial swipe', async () => {
+    const {instance} = renderTestCase();
+    instance.onKeyDown({which: 39 });
+    expect(instance.state.swipeIndex).toEqual(0);
+    instance.onKeyDown({which: 39 });
+    expect(instance.state.swipeIndex).toEqual(0);
+  });
 });


### PR DESCRIPTION
Keyboard navigation using `bindKeyboard` from `react-swipeable-view` is the opposite of what you might expect ("right swipes right").  This happens because in `react-swipeable-view` the assumption is that you're expressing intent to navigate to the right (rather than swiping the row to the right, which effectively navigates left).

This PR removes that and adds our own event listener on top.  It adds tests as well, but the full code path can't be tested since it relies on `react-swipeable-view` using CSS animations, and jsdom doesn't support the transition end event.