### PR TITLE
Test for existence of element.scrollTo

### DIFF
--- a/client/src/ThanksPhase.js
+++ b/client/src/ThanksPhase.js
@@ -28,7 +28,7 @@ class ThanksPhase extends Component {
   // this is a problem on desktop Firefox
   doScrollHack() {
     const el = document.querySelector('.MobileSimulator-background');
-    if (el) el.scrollTo(0, 0);    
+    if (el && el.scrollTo) el.scrollTo(0, 0); // scrollTo isn't supported on older versions of IE
   }
   
   computeMoves() {


### PR DESCRIPTION
This isn't supported on older versions of IE.  Resolves issues like https://rollbar.com/swipe-right-for-cs/swipe-right-for-cs/items/16