### PR TITLE
Guard for workshop input focus getting unmounted

### DIFF
--- a/client/src/WorkshopCode.js
+++ b/client/src/WorkshopCode.js
@@ -36,7 +36,7 @@ class WorkshopCode extends Component {
 
   // Since there's some jank setting the focus while animating.
   onDelaySettled() {
-    this.workshopInputEl.focus();
+    if (this.workshopInputEl) this.workshopInputEl.focus();
   }
 
   onCodeTapped() {


### PR DESCRIPTION
There's some hacking around sequencing here, and we weren't guarding for if the component was unmounted.  Resolves https://rollbar.com/swipe-right-for-cs/swipe-right-for-cs/items/17/