### PR TITLE
Update chooseCohortNumber to force bucketing for code.org study

### DIFF
--- a/client/src/GamePage.js
+++ b/client/src/GamePage.js
@@ -37,9 +37,21 @@ class GamePage extends Component {
     super(props);
     const isCodeOrg = props.isCodeOrg;
     const query = queryString.parse(window.location.search);
+
+    // 12/8 This is a patch to rebalance cells for remaining trials, oversampling from
+    // those that have been undersampled to this point due to randomness.  Going forward
+    // with other experiments, we should switch strategies so that we generate the
+    // experimental cells and then pull from them for each new workshop identifier we see,
+    // to force balance across experimental cells.  This is a workaround for the remaining
+    // sessions of the study that's already underway.
+    const forceCodeOrgBuckets = (isCodeOrg) ? [2, 3, 3, 4, 6, 7] : false;
+    
     this.state = {
       isCodeOrg,
-      config: defaultOptions,
+      config: {
+        ...defaultOptions,
+        forceCodeOrgBuckets
+      },
       sessionId: uuid.v4(),
       identifier: (isCodeOrg)
         ? query.cuid || Session.unknownIdentifier()

--- a/client/src/loaders/loadDataForCohort.test.js
+++ b/client/src/loaders/loadDataForCohort.test.js
@@ -10,7 +10,8 @@ import {
   loadDataForCohort,
   defaultOptions,
   rotatedVariantsForProfiles,
-  shuffleInBuckets
+  shuffleInBuckets,
+  chooseCohortNumber
 } from './loadDataForCohort.js';
 
 function mockCsvFetches() {
@@ -42,6 +43,18 @@ describe('loadDataForCohort', () => {
       runs.push((await loadDataForCohort(uuid.v4(), defaultOptions)).cohortNumber);
     }
     expect(__uniq(runs).sort()).toEqual(__range(0, 10));
+  });
+
+  it('respects forceCodeOrgBuckets', async () => {
+    const forceCodeOrgBuckets = [3, 7];
+    const options = {...defaultOptions, forceCodeOrgBuckets};
+    
+    const runs = [];
+    for (var i = 0; i < 100; i++) {
+      mockCsvFetches();  
+      runs.push((await loadDataForCohort(uuid.v4(), options)).cohortNumber);
+    }
+    expect(__uniq(runs).sort()).toEqual([3, 7]);
   });
 });
 
@@ -136,5 +149,17 @@ describe('rotatedVariantsForProfiles', () => {
     expect(rotatedVariantsForProfiles(0, profiles, variants)).toEqual(['x','y']);
     expect(rotatedVariantsForProfiles(1, profiles, variants)).toEqual(['y','z']);
     expect(rotatedVariantsForProfiles(2, profiles, variants)).toEqual(['z','x']);
+  });
+});
+
+describe('chooseCohortNumber', () => {
+  const forceCodeOrgBuckets = [1, 7, 8];
+  const forcingOptions = {...defaultOptions, forceCodeOrgBuckets};
+
+  it('respects forceCodeOrgBuckets', () => {
+    expect(chooseCohortNumber('abcd', defaultOptions)).toEqual(3);
+    expect(chooseCohortNumber('abcd', forcingOptions)).toEqual(7);
+    expect(chooseCohortNumber('JFDI', defaultOptions)).toEqual(2);
+    expect(chooseCohortNumber('JFDI', forcingOptions)).toEqual(8);
   });
 });


### PR DESCRIPTION
Since the strategy for assigning folks to experimental cells now takes the workshop code and hashes it, this has led to unbalanced cells.  With experiments like this in the future, we should probably use a different strategy (eg, for each new identifier, pull from a prebalanced list of cells).  But for the short-term, this updates to oversample from the cells that to this point have been undersampled.