### PR TITLE
Minimal client-side download CSV chunks for researchers

### DIFF
--- a/client/src/components/DownloadCsvLinks.js
+++ b/client/src/components/DownloadCsvLinks.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+
+
+// Render a set of links that will download a CSV
+// This splits across multiple links, since large CSV cause problems
+// in browsers.
+class DownloadCsvLinks extends Component {
+  render() {  
+    const {headers, rows, chunkSize} = this.props;
+    const chunks = _.chunk(rows, chunkSize);
+    return (
+      <div className="DownloadCsvLinks">
+        <div>Download CSV files:</div>
+        {chunks.map((chunkRows, index) => this.renderChunkLink(headers, chunkRows, index))}
+      </div>
+    );
+  }
+
+  renderChunkLink(headers, rows, index) {
+    const {filename, toLine, delimiter} = this.props;
+    const lines = rows.map(row => toLine(row).join(delimiter));
+    const csvText = [headers.join(delimiter)].concat(lines).join("\n");
+    const chunkFilename = `${index}-${filename}`;
+
+    return (
+      <div key={index}>
+        <a
+          href= {`data:attachment/csv,${window.encodeURIComponent(csvText)}`}
+          target="_blank"
+          download={chunkFilename}
+          style={{paddingLeft: 20}}
+        >{chunkFilename}</a>
+      </div>
+    );
+  }
+}
+
+DownloadCsvLinks.propTypes = {
+  headers: PropTypes.arrayOf(PropTypes.string).isRequired,
+  rows: PropTypes.array.isRequired,
+  filename: PropTypes.string.isRequired,
+  toLine: PropTypes.func.isRequired,
+  chunkSize: PropTypes.number,
+  delimiter: PropTypes.string
+};
+DownloadCsvLinks.defaultProps = {
+  chunkSize: 1000,
+  delimiter: "\t"
+};
+
+export default DownloadCsvLinks;

--- a/client/src/research/InteractionsView.js
+++ b/client/src/research/InteractionsView.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import DownloadCsvLinks from '../components/DownloadCsvLinks';
 import WorkshopsAnalysis from './WorkshopsAnalysis';
 import BiasAnalysis from './BiasAnalysis';
 import RawInteractionsTable from './RawInteractionsTable';
@@ -35,8 +36,24 @@ class InteractionsView extends Component {
         <div className="InteractionView-analysis">
           <div style={{marginBottom: 20, color: 'red'}}>Warning: this includes unconsented data as well.</div>
           <RawInteractionsTable interactions={rawInteractions} />
+          {this.renderDownloadCsvButton(rawInteractions)}
         </div>
       </div>
+    );
+  }
+
+  renderDownloadCsvButton(rawInteractions) {
+    const dateText = 'foo';
+    const filename = `swipe-right-${dateText}.tsv`;
+    const headers = ['ID', 'SESSION', 'INTERACTION', 'TIMESTAMPZ'];
+    return (
+      <DownloadCsvLinks
+        filename={filename}
+        headers={headers}
+        rows={rawInteractions}
+        toLine={row => {
+          return [row.id, JSON.stringify(row.session), JSON.stringify(row.interaction), row.timestampz];
+        }} />
     );
   }
 }


### PR DESCRIPTION
Enabling initial self-serve test.  This is divided into chunks since large files seem to lead to "Network errors" in Chrome otherwise.

<img width="232" alt="screen shot 2018-02-05 at 2 38 22 pm" src="https://user-images.githubusercontent.com/1056957/35824908-555d211a-0a82-11e8-9943-e882515f6fef.png">
