### PR TITLE
Allow configuring ReviewPhase for JLT playtest iterations

### DIFF
--- a/client/src/GamePage.js
+++ b/client/src/GamePage.js
@@ -31,12 +31,16 @@ const Phases = {
   THANKS: 'THANKS'
 };
 
+// See https://github.com/sindresorhus/query-string/issues/50
+function queryHasKey(query, key) {
+  return Object.prototype.hasOwnProperty.call(query, key);
+}
 
 class GamePage extends Component {
   constructor(props) {
     super(props);
     const {isCodeOrg, defaultWorkshopCode} = props;
-    const query = queryString.parse(window.location.search);
+    const query = queryString.parse(window.location.search) || {};
 
     // 12/8 This is a patch to rebalance cells for remaining trials, oversampling from
     // those that have been undersampled to this point due to randomness.  Going forward
@@ -53,8 +57,12 @@ class GamePage extends Component {
         forceCodeOrgBuckets
       },
       sessionId: uuid.v4(),
+      reviewPhaseOptions: {
+        showPercents: !queryHasKey(query, 'reviewnopercents'),
+        copyVersion: query['reviewcopyversion'] || '0'
+      },
       identifier: (isCodeOrg)
-        ? query.cuid || Session.unknownIdentifier()
+        ? query['cuid'] || Session.unknownIdentifier()
         : Session.unknownIdentifier(),
       workshopCode: (defaultWorkshopCode !== undefined)
         ? defaultWorkshopCode
@@ -238,11 +246,12 @@ class GamePage extends Component {
   }
 
   renderReview(phase) {
-    const {students, workshopCode} = this.state;
+    const {students, workshopCode, reviewPhaseOptions} = this.state;
     return <ReviewPhase
       workshopCode={workshopCode}
       students={students}
       onInteraction={this.onInteraction}
+      reviewPhaseOptions={reviewPhaseOptions}
       onDone={() => this.setState({phase})} />;
   }
 

--- a/client/src/ReviewPhase.js
+++ b/client/src/ReviewPhase.js
@@ -31,7 +31,13 @@ class ReviewPhase extends Component {
   }
 
   render() {
-    const {workshopCode, students, onInteraction, onDone} = this.props;
+    const {
+      workshopCode,
+      students,
+      onInteraction,
+      onDone,
+      reviewPhaseOptions
+    } = this.props;
     const {peerResponses} = this.state;
     if (peerResponses === null) return null;
     return (
@@ -41,6 +47,7 @@ class ReviewPhase extends Component {
         peerResponses={peerResponses}
         onInteraction={onInteraction}
         onDone={onDone}
+        reviewPhaseOptions={reviewPhaseOptions}
       />
     );
   }
@@ -50,7 +57,11 @@ ReviewPhase.propTypes = {
   workshopCode: PropTypes.string.isRequired,
   students: PropTypes.arrayOf(PropTypes.object).isRequired,
   onInteraction: PropTypes.func.isRequired,
-  onDone: PropTypes.func.isRequired
+  onDone: PropTypes.func.isRequired,
+  reviewPhaseOptions: PropTypes.shape({
+    showPercents: PropTypes.bool.isRequired,
+    copyVersion: PropTypes.string.isRequired
+  })
 };
 
 export default ReviewPhase;

--- a/client/src/ReviewPhase.test.js
+++ b/client/src/ReviewPhase.test.js
@@ -17,7 +17,11 @@ function testProps() {
     workshopCode: "foo",
     students: storybookStudents,
     onDone: jest.fn(),
-    onInteraction: jest.fn()
+    onInteraction: jest.fn(),
+    reviewPhaseOptions: {
+      showPercents: true,
+      copyVersion: 'unknown'
+    }
   };
 }
 

--- a/client/src/ReviewPhaseView.js
+++ b/client/src/ReviewPhaseView.js
@@ -8,6 +8,27 @@ import Swipeable from './components/Swipeable.js';
 import {Interactions} from './shared/data.js';
 import './ReviewPhaseView.css';
 
+
+function copyFor(copyVersion) {
+  // for JLT playest iteration on 3/22
+  if (copyVersion === 'jlt1') {
+    return (
+      <div>
+        <p>{"Here are the top three arguments for each student, based on how other folks in the workshop responded."}</p>
+        <p>{"Why do you think folks chose different arguments for different students?"}</p>
+      </div>
+    );
+  }
+
+  // Default copy
+  return (
+    <div>
+      <p>{"Here are the top three arguments for each student, based on how other folks in the workshop responded."}</p>
+      <p>{"How would you approach recruiting conversations differently with different students?"}</p>
+    </div>
+  );
+}
+
 // Review peer responses within the workshop.
 class ReviewPhaseView extends Component {
   constructor(props) {
@@ -22,13 +43,14 @@ class ReviewPhaseView extends Component {
   }
 
   render() {
-    const {students} = this.props;
+    const {students, reviewPhaseOptions} = this.props;
+    const {copyVersion} = reviewPhaseOptions;
+    const copyEl = copyFor(copyVersion);
     return (
       <div className="ReviewPhaseView">
         <div className="ReviewPhaseView-content">
           <p className="Global-header-font">Round 3: Review</p>
-          <p>{"Here are the top three arguments for each student, based on how other folks in the workshop responded."}</p>
-          <p>{"How would you approach recruiting conversations differently with different students?"}</p>
+          {copyEl}
         </div>
         <div className="ReviewPhaseView-students">
           {students.map((student) => {
@@ -61,7 +83,8 @@ class ReviewPhaseView extends Component {
   }
 
   renderPeerResponses(student) {
-    const {peerResponses} = this.props;
+    const {peerResponses, reviewPhaseOptions} = this.props;
+    const {showPercents} = reviewPhaseOptions; // added for disabling on JLT playest iteration on 3/22
     const topN = 3;
     const rows = __groupBy(peerResponses, 'profileName')[student.profileName] || [];
     const sortedRows = __orderBy(rows, ['percentageRight'], ['desc']);
@@ -70,9 +93,11 @@ class ReviewPhaseView extends Component {
         {sortedRows.slice(0, topN).map(row =>
           <div key={row.argumentText} className="ReviewPhaseView-argument-container">
             <Bubble>{row.argumentText}</Bubble>
-            <div className="ReviewPhaseView-percentage" style={{width: `${row.percentageRight}%`}}>
-              <div className="ReviewPhaseView-percentage-text">{row.percentageRight}%</div>
-            </div>
+            {showPercents && (
+              <div className="ReviewPhaseView-percentage" style={{width: `${row.percentageRight}%`}}>
+                <div className="ReviewPhaseView-percentage-text">{row.percentageRight}%</div>
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -85,7 +110,11 @@ ReviewPhaseView.propTypes = {
   students: PropTypes.arrayOf(PropTypes.object).isRequired,
   peerResponses: PropTypes.arrayOf(PropTypes.object).isRequired,
   onInteraction: PropTypes.func.isRequired,
-  onDone: PropTypes.func.isRequired
+  onDone: PropTypes.func.isRequired,
+  reviewPhaseOptions: PropTypes.shape({
+    showPercents: PropTypes.bool.isRequired,
+    copyVersion: PropTypes.string.isRequired
+  })
 };
 
 export default ReviewPhaseView;

--- a/client/src/ReviewPhaseView.story.js
+++ b/client/src/ReviewPhaseView.story.js
@@ -6,6 +6,14 @@ import ReviewPhaseView from './ReviewPhaseView.js';
 import {storybookStudents} from './util/fixtures.js';
 import {peerResponsesLong} from './util/peerResponsesFixtures.js';
 
+function reviewPhaseOptions(props = {}) {
+  return {
+    showPercents: true,
+    copyVersion: 'unknown',
+    ...props
+  };
+}
+
 storiesOf('ReviewPhaseView', module) //eslint-disable-line no-undef
   .add('normal', () => {
     return withFrameSwitcher(
@@ -14,6 +22,29 @@ storiesOf('ReviewPhaseView', module) //eslint-disable-line no-undef
         students={storybookStudents}
         peerResponses={peerResponsesLong}
         onInteraction={action('onInteraction')}
-        onDone={action('onDone')} />
+        onDone={action('onDone')}
+        reviewPhaseOptions={reviewPhaseOptions()} />
+    );
+  })
+  .add('showPercents=false', () => {
+    return withFrameSwitcher(
+      <ReviewPhaseView
+        workshopCode="foo"
+        students={storybookStudents}
+        peerResponses={peerResponsesLong}
+        onInteraction={action('onInteraction')}
+        onDone={action('onDone')}
+        reviewPhaseOptions={reviewPhaseOptions({showPercents: false})} />
+    );
+  })
+  .add('copyVersion=jlt1', () => {
+    return withFrameSwitcher(
+      <ReviewPhaseView
+        workshopCode="foo"
+        students={storybookStudents}
+        peerResponses={peerResponsesLong}
+        onInteraction={action('onInteraction')}
+        onDone={action('onDone')}
+        reviewPhaseOptions={reviewPhaseOptions({copyVersion: 'jlt1'})} />
     );
   });

--- a/client/src/ReviewPhaseView.test.js
+++ b/client/src/ReviewPhaseView.test.js
@@ -5,13 +5,18 @@ import {storybookStudents} from './util/fixtures.js';
 import {peerResponses} from './util/peerResponsesFixtures.js';
 
 
-function testProps() {
+function testProps(props = {}) {
   return {
     workshopCode: "foo",
     students: storybookStudents,
     peerResponses: peerResponses,
     onDone: jest.fn(),
-    onInteraction: jest.fn()
+    onInteraction: jest.fn(),
+    reviewPhaseOptions: {
+      showPercents: true,
+      copyVersion: 'unknown'
+    },
+    ...props
   };
 }
 
@@ -19,4 +24,47 @@ it('renders without crashing', async () => {
   const div = document.createElement('div');
   const props = testProps();
   ReactDOM.render(<ReviewPhaseView {...props} />, div);
+});
+
+
+describe('copyVersion option', () => {
+  it('has default copy', async () => {
+    const div = document.createElement('div');
+    const props = testProps();
+    ReactDOM.render(<ReviewPhaseView {...props} />, div);
+    expect(div.innerHTML).toContain('How would you approach recruiting conversations differently with different students?');
+  });
+
+  it('has copy for jlt1', async () => {
+    const div = document.createElement('div');
+    const props = testProps({
+      reviewPhaseOptions: {
+        showPercents: true,
+        copyVersion: 'jlt1'
+      }
+    });
+    ReactDOM.render(<ReviewPhaseView {...props} />, div);
+    expect(div.innerHTML).toContain('Why do you think folks chose different arguments for different students?');
+  });
+});
+
+describe('showPercents option', () => {
+  it('shows them by default', async () => {
+    const div = document.createElement('div');
+    const props = testProps();
+    ReactDOM.render(<ReviewPhaseView {...props} />, div);
+    expect(div.querySelectorAll('.ReviewPhaseView-percentage').length).toEqual(8);
+  });
+
+  it('can disable them', async () => {
+    const div = document.createElement('div');
+    const props = testProps({
+      reviewPhaseOptions: {
+        showPercents: false,
+        copyVersion: 'unknown'
+      }
+    });
+    ReactDOM.render(<ReviewPhaseView {...props} />, div);
+    expect(div.querySelectorAll('.ReviewPhaseView-percentage').length).toEqual(0);
+  });
 });


### PR DESCRIPTION
For a playtest iteration today.

Example URL:
```
http://localhost:3000/group/tsl20180322?open&reviewnopercents&reviewcopyversion=jlt1
```
The group key is for tagging the playtest and `open` includes open responses.  The new flags for today are `reviewnopercents` and `reviewcopyversion`.

No percents in review phase:
<img width="311" alt="screen shot 2018-03-22 at 10 12 55 am" src="https://user-images.githubusercontent.com/1056957/37775726-12a54518-2dba-11e8-9adb-f977913f01a5.png">

Updated review copy:
<img width="306" alt="screen shot 2018-03-22 at 10 13 01 am" src="https://user-images.githubusercontent.com/1056957/37775737-1a20f9e0-2dba-11e8-9da1-227c500bfa70.png">
