### PR TITLE
Add swipe arrows and allow mouse clicks

### DIFF
--- a/client/src/Title.js
+++ b/client/src/Title.js
@@ -34,6 +34,7 @@ class Title extends Component {
         </p>
         <Delay wait={250}>
           <Swipeable
+            style={{width: '100%'}}
             height={swipeHeight}
             onSwipeRight={this.onSwipeRight}>
             <div className="Title-swipe">

--- a/client/src/components/Bubble.css
+++ b/client/src/components/Bubble.css
@@ -7,16 +7,3 @@
   color: black;
   border: 1px solid #cae2ef;
 }
-.Bubble:after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  width: 0;
-  height: 0;
-  border: 6px solid transparent;
-  border-top-color: #cae2ef;
-  border-bottom: 0;
-  margin-left: -6px;
-  margin-bottom: -6px;
-}

--- a/client/src/components/Swipeable.css
+++ b/client/src/components/Swipeable.css
@@ -1,7 +1,6 @@
-.Swipeable {
+.Swipeable {  
   display: flex;
   align-items: center;
-  width: 100%;
   overflow-y: hidden;
 }
 
@@ -21,14 +20,41 @@
   background-color: rgb(37, 214, 137);
 }
 
+.Swipeable-right {
+  flex: 1;
+  background-color: rgb(226, 170, 22);
+}
+
+.Swipeable-arrow-for-swipe-left {
+  position: absolute;
+  color: rgb(226, 170, 22);
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.Swipeable-arrow-for-swipe-right {
+  position: absolute;
+  color: rgb(37, 214, 137);
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
 .Swipeable-children {
   flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  position: relative;
 }
 
-.Swipeable-right {
-  flex: 1;
-  background-color: rgb(226, 170, 22);
-}
+

--- a/client/src/components/Swipeable.css
+++ b/client/src/components/Swipeable.css
@@ -27,11 +27,13 @@
 
 .Swipeable-arrow-for-swipe-left {
   position: absolute;
+  cursor: pointer;
   color: rgb(226, 170, 22);
-  left: 0;
+  left: 1px;
   top: 0;
   bottom: 0;
-  width: 20px;
+  font-size: 16px;
+  font-weight: bold;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -39,11 +41,13 @@
 
 .Swipeable-arrow-for-swipe-right {
   position: absolute;
+  cursor: pointer;
   color: rgb(37, 214, 137);
-  right: 0;
+  right: 1px;
   top: 0;
   bottom: 0;
-  width: 20px;
+  font-size: 16px;
+  font-weight: bold;
   display: flex;
   align-items: center;
   justify-content: flex-end;

--- a/client/src/components/Swipeable.js
+++ b/client/src/components/Swipeable.js
@@ -52,10 +52,10 @@ class Swipeable extends Component {
   }
 
   render() {
-    const {height} = this.props;
+    const {height, style} = this.props;
 
     return (
-      <div className="Swipeable" style={{height: height}}>
+      <div className="Swipeable" style={{...style, height}}>
         <Bounceable height={height}>
           {this.renderSwipeable()}
         </Bounceable>
@@ -113,7 +113,8 @@ Swipeable.propTypes = {
   children: PropTypes.node.isRequired,
   height: PropTypes.number.isRequired,
   onSwipeRight: PropTypes.func.isRequired,
-  onSwipeLeft: PropTypes.func
+  onSwipeLeft: PropTypes.func,
+  style: PropTypes.object
 };
 
 export default Swipeable;

--- a/client/src/components/Swipeable.js
+++ b/client/src/components/Swipeable.js
@@ -77,7 +77,17 @@ class Swipeable extends Component {
     
     const elements = __compact([
       <div key="left" className="Swipeable-left">&nbsp;</div>,
-      <div key="children" className="Swipeable-children">{children}</div>,
+      <div key="children" className="Swipeable-children">
+        {onSwipeLeft && (
+          <div
+            className="Swipeable-arrow-for-swipe-left" 
+            onClick={() => this.onChangeIndex(2)}>◀</div>
+        )}
+        {children}
+        <div
+          className="Swipeable-arrow-for-swipe-right"
+          onClick={() => this.onChangeIndex(0)}>▶</div>
+      </div>,
       onSwipeLeft && <div key="right" className="Swipeable-right">&nbsp;</div>
     ]);
     return (


### PR DESCRIPTION
This adds another visual cue about what "swiping" means.  Folks can press arrow keys in these directions already, and now they can also click on these small arrows.

This is trying to make the minimal change now to fit within the space constraints, but we could increase the mobile simulator container size since code.org teachers will all have to be on laptops anyway.

![image](https://user-images.githubusercontent.com/1056957/45577839-23a76b80-b84c-11e8-9aac-9699ba6611d8.png)
![image](https://user-images.githubusercontent.com/1056957/45577844-24d89880-b84c-11e8-990e-459645a16be3.png)
