### PR TITLE
Fix bug with querying for peer responses in unescaped URL

### DIFF
--- a/client/src/ReviewPhase.js
+++ b/client/src/ReviewPhase.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReviewPhaseView from './ReviewPhaseView.js';
 import {error} from './shared/log.js';
+import qs from 'query-string';
+
 
 // Review peer responses within the workshop.
 class ReviewPhase extends Component {
@@ -16,7 +18,7 @@ class ReviewPhase extends Component {
 
   componentDidMount() {
     const {workshopCode} = this.props;
-    fetch(`/api/peers/${workshopCode}`)
+    fetch(`/api/peers?${qs.stringify({workshopCode})}`)
       .then(r => r.json())
       .then(this.onDataLoaded)
       .catch(this.onDataError);

--- a/server/game/endpoints.js
+++ b/server/game/endpoints.js
@@ -31,7 +31,7 @@ function logEndpoint(pool, req, res) {
 function peerResponsesEndpoint(pool, req, res) {
   res.set('Content-Type', 'application/json');
   
-  const {workshopCode} = req.params;
+  const {workshopCode} = req.query;
   queryForGroupedResponses(pool, workshopCode)
     .catch(err => {
       console.log('query returned err: ', err);

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ const limiter = new RateLimit({
 
 // Endpoints for the game
 app.post('/api/log', logEndpoint.bind(null, pool));
-app.get('/api/peers/:workshopCode', peerResponsesEndpoint.bind(null, pool));
+app.get('/api/peers', peerResponsesEndpoint.bind(null, pool));
 app.post('/api/share', limiter, emailMyResponsesEndpoint.bind(null, config.mailgunEnv));
 
 


### PR DESCRIPTION
After the change for "v3" workshop codes, composited from the actual workshop code and a "table number" (in https://github.com/mit-teaching-systems-lab/swipe-right-for-cs/pull/108/files#diff-7bf6fde7ab06e718b4bd09d150351ef1R80), the workshop code string always contains a slash.  This revealed a bug in the query for peer responses, since that query didn't escape the workshop code value.  The bug led to the UI code querying for a page that the server didn't understand, and the server returning the HTML page when the UI was expecting JSON.  The UI would fail to parse the JSON, and would white screen.    See https://rollbar.com/swipe-right-for-cs/swipe-right-for-cs/items/29/ and related.

This would happen during the transition to the "review phase," which meant folks coming from Code Studio wouldn't see the "discuss phase" or the "thanks" screen at the end.

This PR updates the query to be a query string param and be properly escaped.