### PR TITLE
Include full paths to images in emails

### DIFF
--- a/server/authentication.js
+++ b/server/authentication.js
@@ -243,5 +243,6 @@ module.exports = {
   enforceHTTPS,
   onlyAllowResearchers,
   loginEndpoint,
-  emailLinkEndpoint
+  emailLinkEndpoint,
+  getDomain
 };

--- a/server/game/emails/responses.html.mustache
+++ b/server/game/emails/responses.html.mustache
@@ -132,7 +132,7 @@
                                         {{#moves}}
                                         <tr>
                                             <td align="center" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family:Helvetica, Arial, sans-serif; color: #666666;" class="padding">
-                                                <img src="{{profileImageSrc}}" /></td>
+                                                <img src="{{domain}}{{profileImageSrc}}" /></td>
                                         </tr>
                                         <tr>
                                             <td align="center" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family:Helvetica, Arial, sans-serif; color: #666666;" class="padding">

--- a/server/game/endpoints.js
+++ b/server/game/endpoints.js
@@ -1,6 +1,6 @@
 const {queryForGroupedResponses} = require('./peerResponses.js');
 const {sendResponsesEmail} = require('./sendEmails.js');
-
+const {getDomain} = require('../authentication.js');
 
 // For receiving log data from the client
 function logEndpoint(pool, req, res) {
@@ -49,7 +49,8 @@ function emailMyResponsesEndpoint(mailgunEnv, req, res) {
   const {moves, email} = req.body;
 
   // Send email with responses
-  sendResponsesEmail(email, moves, mailgunEnv);
+  const domain = getDomain(req);
+  sendResponsesEmail(email, moves, domain, mailgunEnv);
 
   // Return success no matter what
   res.set('Content-Type', 'application/json');

--- a/server/game/sendEmails.js
+++ b/server/game/sendEmails.js
@@ -44,12 +44,12 @@ function sendConsentEmail(mailgunEnv, email) {
 }
 
 // Send email to self with responses
-function sendResponsesEmail(email, moves, mailgunEnv) {
+function sendResponsesEmail(email, moves, domain, mailgunEnv) {
   console.log('Sending responses email, email hash: ' + sha(email));
 
   const hereYouGoText = 'Here are your responses from the game.';
   const responsesFilename = path.join(__dirname, '/emails/responses.html.mustache');
-  const html = renderEmail(responsesFilename, {hereYouGoText, moves});
+  const html = renderEmail(responsesFilename, {hereYouGoText, moves, domain});
   const info = {
     toEmail: email,
     fromEmail: 'swipe-right-bot@tsl.mit.edu',


### PR DESCRIPTION
These are relative paths, so emails don't know what to do with them and it looks like this in desktop web GMail:
<img width="563" alt="screen shot 2018-10-03 at 11 41 36 am" src="https://user-images.githubusercontent.com/1056957/46421983-592fce00-c701-11e8-9978-e01616dfbe34.png">


This PR adds the domain in on the server.

There's no way to fully verify this without deploying, but this does what's expecting if I run the local code through Mailgun and check what GMail's proxy queries for.